### PR TITLE
Add maxdeviant.com to webring

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -55,5 +55,6 @@ let sites = [
       , "https://neufv.website"
       , "https://simbolo.xyz"
       , "https://ricky.codes"
+      , "https://maxdeviant.com"
     ];
     // Don't forget the comma! No trailing slashes


### PR DESCRIPTION
Add [maxdeviant.com](https://maxdeviant.com/). Webring icon is located in the header.

Finally got around to doing this :tada: 