### PR TITLE
fix http on http://evenunto.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Instead of linking to the directory, you can also link to the next link in the r
 
 ## API
 
-This repository does not contain mature API capabilities, but there is one way to request list of sites currently in the webring.
+This repository does not contain mature API capabilities, but there are a couple ways to request a list of sites currently in the webring.
 
 - Request [sites.js on xxiivv](https://webring.xxiivv.com/scripts/sites.js) or [sites.js on github](https://raw.githubusercontent.com/XXIIVV/webring/master/scripts/sites.js)
-- Parse it as text from `[` to `]`, split by `,` and then trim all whitespace and `"` in resulting array.
+- Then parse it as text from `[` to `]`, split by `,` and then trim all whitespace and `"` in resulting array.
+- If you'd like a already parsed list, [webring-checker.now.sh/sites](https://webring-checker.now.sh/sites) will return an json array of the sites in the webring. See [webring-checker.now.sh](https://webring-checker.now.sh) for more info.
 
 ## Need Help?
 

--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -14,7 +14,7 @@ const sites = [
   , "https://electricgecko.de"
   , "https://wichniow.ski"
   , "https://hraew.autophagy.io"
-  , "https://evenunto.net"
+  , "http://evenunto.net"
   , "https://anxl.faith"
   , "https://xvw.github.io"
   , "https://heracl.es"


### PR DESCRIPTION
Currently this site is listed as https, but if someone gets directed there with https, they'll end up getting an insecure warning since there is no valid ssl. I think we should change this to http in order to not have users get this warning.