### PR TITLE
Update readme to include reference to api

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Instead of linking to the directory, you can also link to the next link in the r
 
 ## API
 
-This repository does not contain mature API capabilities, but there is one way to request list of sites currently in the webring.
+This repository does not contain mature API capabilities, but there are a couple ways to request a list of sites currently in the webring.
 
 - Request [sites.js on xxiivv](https://webring.xxiivv.com/scripts/sites.js) or [sites.js on github](https://raw.githubusercontent.com/XXIIVV/webring/master/scripts/sites.js)
-- Parse it as text from `[` to `]`, split by `,` and then trim all whitespace and `"` in resulting array.
+- Then parse it as text from `[` to `]`, split by `,` and then trim all whitespace and `"` in resulting array.
+- If you'd like a already parsed list, [webring-checker.now.sh/sites](https://webring-checker.now.sh/sites) will return an json array of the sites in the webring. See [webring-checker.now.sh](https://webring-checker.now.sh) for more info.
 
 ## Need Help?
 


### PR DESCRIPTION
So I wasn't positive if you'd want this referenced or not in the repo, but I figured I'd send this in either way. If not, no worries at all. If someone does want just a json array of sites, this will give it to them.

Another idea I played around with was it'd also be easy to quickly check if the next site is up before directing someone to it, and if so, then continue on. I thought about implementing that, but it didn't make tons of sense to provide that here since the current webring url is where everything is centered around.

Either way, I'll try to keep an eye on the reports here and ping people if I notice sites are down for more than a week or so.