### PR TITLE
add notes.stuartpb.com to sites.js

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -88,5 +88,6 @@ const sites = [
   { url: 'https://colectivo-de-livecoders.gitlab.io/', title: 'Colectivo de Livecoders', type: 'blog', author: 'clic', contact: 'https://t.me/clic_laplata' },
   { url: 'https://www.madewithtea.com', title: 'madewithtea.com', type: 'blog' },
   { url: 'https://amorris.ca', title: 'amorris', author: 'amorris', type: 'blog', feed: 'https://feed.amorris.ca/hallway.txt' },
-  { url: 'http://www.miha-co.ca', title: 'miha-co', type: 'Portfolio' }
+  { url: 'http://www.miha-co.ca', title: 'miha-co', type: 'Portfolio' },
+  { url: 'https://notes.stuartpb.com/', title: 'notes.stuartpb.com', type: 'wiki', author: 'stuartpb', contact: 's@stuartpb.com', feed: 'https://twtxt.stuartpb.com/xxiivv.txt' }
 ]


### PR DESCRIPTION
The webring icon is at the bottom of the content on https://notes.stuartpb.com/ (fixed since submitting #165).