### PR TITLE
Add self, take 2

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -93,4 +93,5 @@ const sites = [
   { url: 'https://notes.stuartpb.com/', title: 'notes.stuartpb.com', type: 'wiki', author: 'stuartpb', contact: 's@stuartpb.com', feed: 'https://twtxt.stuartpb.com/xxiivv.txt' },
   { url: 'http://xxiii.co', title: 'xxiii', type: 'wiki', author: 'serocell', contact: 'psignal@s900.net', rss: 'http://serocell.com/feeds/serocell.xml' },
   { url: 'https://kor.nz', title: 'kor', type: 'wiki', author: 'kormyen', contact: 'h@kor.nz' },
+  { url: 'https://lublin.se', author: 'quite', contact: "quite@hack.org", feed: 'https://lublin.se/twtxt.txt' }
 ]


### PR DESCRIPTION
Webring link is in the footer of site index page. https://lublin.se

Sry, for buggy self before. And I was probably restarting nginx to add
CORS handling when you tried the site...