### PR TITLE
Remove eswat.ca from sites.js

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -37,7 +37,6 @@ const sites = [
   { url: 'https://systems.ws' },
   { url: 'https://jamesin.space' },
   { url: 'https://nathanwentworth.co' },
-  { url: 'https://eswat.ca' },
   { url: 'https://uonai.space' },
   { url: 'http://controls.ee' },
   { url: 'https://wasin.io' },


### PR DESCRIPTION
Closes #193. Removing for now since my site doesn't meet the README criteria.