### PR TITLE
Parse glossary from site wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <script src="scripts/portal.js"></script>
   <script src="scripts/sites.js"></script>
   <script src="scripts/opml.js"></script>
+  <script src="scripts/wiki.js"></script>
   <title>Webring</title>
 </head>
 <body>

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -12,7 +12,7 @@ function Portal (sites) {
   }
 
   function _buttons () {
-    return `<p class='buttons'><a href='#random' onClick="portal.reload('random')">Random</a> | <a href='https://github.com/XXIIVV/webring'>Information</a> <a id='icon'  href='#random' onClick="portal.reload('random')"></a> | <a href="hallway.html">The Hallway</a> | <a id="opml">OPML</a></p>`
+    return `<p class='buttons'><a href='#random' onClick="portal.reload('random')">Random</a> | <a href='https://github.com/XXIIVV/webring'>Information</a> <a id='icon'  href='#random' onClick="portal.reload('random')"></a> | <a href="hallway.html">The Hallway</a> | <a id="opml">OPML</a> | <a id="wiki">WIKI</a></p>`
   }
 
   function _directory (sites) {

--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -4,7 +4,7 @@
 // protocol://url.domain.ext
 
 const sites = [
-  { url: 'https://wiki.xxiivv.com', title: 'xxiivv', type: 'wiki', author: 'neauoire', contact: 'aliceffekt@gmail.com', rss: 'https://wiki.xxiivv.com/links/rss.xml', feed: 'https://wiki.xxiivv.com/twtxt.txt' },
+  { url: 'https://wiki.xxiivv.com', title: 'xxiivv', type: 'wiki', author: 'neauoire', contact: 'aliceffekt@gmail.com', rss: 'https://wiki.xxiivv.com/links/rss.xml', feed: 'https://wiki.xxiivv.com/twtxt.txt', wiki: 'https://wiki.xxiivv.com/scripts/database/glossary.ndtl' },
   { url: 'http://estevancarlos.com' },
   { url: 'https://electro.pizza', title: 'electro pizza', type: 'blog', author: 'rho', rss: 'https://electro.pizza/feed.xml', feed: 'https://electro.pizza/twtxt.txt' },
   { url: 'https://ianjbattaglia.co' },
@@ -85,7 +85,7 @@ const sites = [
   { url: 'https://teknari.com' },
   { url: 'https://colectivo-de-livecoders.gitlab.io/', title: 'Colectivo de Livecoders', type: 'blog', author: 'clic', contact: 'https://t.me/clic_laplata' },
   { url: 'https://www.madewithtea.com', title: 'madewithtea.com', type: 'blog' },
-  { url: 'https://amorris.ca', title: 'amorris', author: 'amorris', type: 'blog', feed: 'https://feed.amorris.ca/hallway.txt' },
+  { url: 'https://amorris.ca', title: 'amorris', author: 'amorris', type: 'blog', feed: 'https://feed.amorris.ca/hallway.txt', wiki: 'https://wiki.amorris.ca' },
   { url: 'http://www.miha-co.ca', title: 'miha-co', type: 'Portfolio' },
   { url: 'https://buzzert.net', title: 'buzzert.net', author: 'buzzert', type: 'blog' },
   { url: 'https://notes.stuartpb.com/', title: 'notes.stuartpb.com', type: 'wiki', author: 'stuartpb', contact: 's@stuartpb.com', feed: 'https://twtxt.stuartpb.com/xxiivv.txt' },

--- a/scripts/wiki.js
+++ b/scripts/wiki.js
@@ -1,0 +1,36 @@
+// Wikis
+
+parseGlossary = function (text) {
+  return Promise.resolve(text)
+}
+
+loadGlossary = function (wikiUrl) {
+  return fetch(wikiUrl).then(resp => {
+    const content = resp.headers.get('content-type').split(';')[0]
+    switch (content) {
+      case 'text/html':
+        return resp.text().then(text => {
+          const glossaryURL = new DOMParser()
+            .parseFromString(text, 'text/html')
+            .querySelector('link[rel=glossary]')
+            .getAttribute('href')
+          return fetch(`${wikiUrl}/${glossaryURL}`)
+            .then(x => x.text())
+            .then(parseGlossary)
+        }).catch(err => {
+          console.warn(`Could not fetch glossary at ${wikiUrl}: ${err}`)
+        })
+      default:
+        return resp.text().then(parseGlossary)
+    }
+  })
+}
+
+window.onload = function () {
+  let a = document.getElementById('wiki')
+  let wikis = portal.sites.filter(site => site.wiki)
+  let {wiki} = wikis[Math.floor(Math.random() * wikis.length)]
+  loadGlossary(wiki).then(
+    glossary => a.title = glossary
+  )
+}


### PR DESCRIPTION
Posting up mostly for reference/discussion rather than an intent to merge

```
[x] Code can be content-type aware and expect a glossary link on a wiki homepage.
[x] Example: hover over the new wiki link to see alt-text of a random wiki's glossary.
[ ] Actually parse the ndtl and do something useful to it.
[ ] Allow a content type of `application/json` which simply skips indental parsing.
```
