### PR TITLE
Updated to include new ndtl link

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -79,7 +79,7 @@ const sites = [
   { url: 'https://xinniw.github.io' },
   { url: 'https://mboxed.github.io/forida' },
   { url: 'https://letters.vexingworkshop.com' },
-  { url: 'https://tom.org.nz', title: 'Tom Hackshaw', type: 'Portfolio', author: 'tomupom', contact: 'tom@tomhackshaw.com', feed: 'https://tom.org.nz/scripts/twtxt.txt' },
+  { url: 'https://tom.org.nz', title: 'Tom Hackshaw', type: 'Portfolio', author: 'tomupom', contact: 'tom@tomhackshaw.com', wiki: 'https://a.tom.org.nz/glossary.ndtl' },
   { url: 'https://teknari.com' },
   { url: 'https://colectivo-de-livecoders.gitlab.io', title: 'Colectivo de Livecoders', type: 'blog', author: 'clic', contact: 'https://t.me/clic_laplata' },
   { url: 'https://www.madewithtea.com', title: 'madewithtea.com', type: 'blog' },


### PR DESCRIPTION
Switched host with CORS headers enabled for glossary.ndtl and have changed the link accordingly, thank you!