### PR TITLE
Filter out messages with external references

### DIFF
--- a/scripts/hallway.js
+++ b/scripts/hallway.js
@@ -3,7 +3,7 @@
 const reChannel = /(\s|^)\/([a-zA-Z0-9]+)/g
 const reUser = /((\s|^)@&lt;[a-zA-Z0-9./:\-_+~#= ]*&gt;)/g
 const reTag = /([^&]|^)#([a-zA-Z0-9]+)/g
-const reUrl = /((https?):\/\/(([-a-zA-Z0-9j:%._+~#=]{2,256}\.[a-z]{2,6}\b)([-a-zA-Z0-9@:%_+.~#?&//=]*)))/g
+const reUrl = /((https?):\/\/(([-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b)([-a-zA-Z0-9@:%_+.~#?&//=]*)))/g
 
 function Hallway (sites) {
   const feeds = {}


### PR DESCRIPTION
This will do what we mentioned on the hallway regarding filtering out messages that reference individuals that aren't in the hallway. I think this will be a good idea for people that are using twtxt and not just following people in the hallway. This way messages can't be targeted at people not in the hallway, and then those messages just get filtered out.

I also did a bit of cleanup on various things.