### PR TITLE
[wiki] fix sidebar navigation constraints

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -85,8 +85,8 @@ body #portal ul li a:hover { text-decoration: underline; }
 body #wiki { background: #ccc; color:#333; }
 body #wiki #entry { max-width: calc(100% - 230px); margin-bottom: 30px; line-height: 15px }
 body #wiki #entry a { text-decoration: underline; }
+body #wiki #sidebar { overflow-y: scroll; height: calc(100% - 15px); }
 body #wiki ul.term { border-bottom: 0px; margin-bottom: 0px; padding-bottom: 0px}
 body #wiki ul.term li { margin-bottom: 5px }
 body #wiki ul.term li.name { margin-bottom: 5px }
 body #wiki ul.term li a.author { color:#555; text-decoration: none !important; }
-


### PR DESCRIPTION
general problem i have is this site w/o zooming-in is unreadable:
![Screenshot--20190807-151126](https://user-images.githubusercontent.com/39516339/62631904-d33c6f00-b931-11e9-9492-900f57d73942.png)

but with zoom, sidebar list is just cut off:
![Screenshot--20190807-152756](https://user-images.githubusercontent.com/39516339/62631911-d7688c80-b931-11e9-91cd-37fb88621e1c.png)

now it has a vertical scrollbar.