### PR TITLE
Rewrite of wiki, semantic html, style changes... and more

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -58,10 +58,10 @@ body #wiki { background: #ccc; color:#333; }
 body #wiki main { display: flex; }
 body #wiki main { flex: 1; }
 body #wiki main { max-width: calc(100% - 230px); }
-body #wiki main a { text-decoration: underline; }
 body #wiki main h1 { font-size: 1.3em; margin: 5px 0; font-weight: bold; }
 body #wiki main div.related { border-bottom: 1px solid white; margin-bottom: 10px; }
 body #wiki #main { width: 100%; }
+body #wiki #main a { text-decoration: underline; }
 body #wiki #main ul li { line-height: 15px; }
 body #wiki aside { min-width: 220px; }
 body #wiki aside  { overflow-y: scroll; height: calc(100% - 15px); position: absolute; right: 0;}

--- a/links/main.css
+++ b/links/main.css
@@ -1,39 +1,39 @@
 * { margin:0;padding:0;border:0;outline:0;text-decoration:none;font-weight:inherit;font-style:inherit;color:inherit;font-size:100%;font-family:inherit;vertical-align:baseline;list-style:none;border-collapse:collapse;border-spacing:0; -webkit-font-smoothing: antialiased;-moz-osx-font-smoothing: grayscale;}
 
 body { background:#f4f4f4; padding:0px; margin:0px; }
-body > div { display:block; background: #111;min-height: calc(100vh - 60px);width: calc(100vw - 60px);margin: 15px;color: #333;padding: 15px;font-family:'input_mono_regular', 'Monospaced','Courier New',courier;font-size:11px; position: relative; border-radius: 2px; color:white; overflow: hidden;}
-body > div > ul { max-width: 800px; padding-bottom: 15px;margin-bottom:15px; overflow: hidden;}
-body div p { display:block; padding:0px 5px; line-height: 20px; max-width: 600px}
-body div p a { text-decoration: underline; cursor: pointer;}
-body div p a:hover { text-decoration: underline; }
+body > div { background: #111; min-height: calc(100vh - 60px); width: calc(100vw - 60px); margin: 15px; padding: 15px; font-family:'input_mono_regular', 'Monospaced','Courier New',courier; font-size:11px; color:white; position: relative; }
+body > div > ul { padding-bottom: 15px; margin-bottom:15px; }
+body div p { display:block; padding:0px 5px; line-height: 20px;}
+body footer { border-top: 2px solid white; padding-top: 15px; margin-top: 15px;}
+body footer a { text-decoration: underline; }
 body strong { font-weight: normal; font-family: 'input_mono_medium' }
-body div p.readme { max-width:500px; }
-body .col3 { columns:3; }
 body .selected { background: white; color:black; }
 
-body #sidebar { position: absolute;top: 0px;right: 0px;padding: 15px;width: 200px; overflow: hidden;}
-body #sidebar > * { border-bottom: 0px; line-height: 16px; padding-bottom: 0px }
-body #sidebar ul { margin-bottom: 15px }
-body #sidebar > * li { text-transform: lowercase; }
-body #sidebar > * li:hover { cursor: pointer; }
-body #sidebar > * li span.right { color:#555; float:right; }
-body #sidebar > * li span.right:after { content: " msgs"; }
-body #sidebar #channels li:before, body #sidebar #categories li:before { content:'/'; }
-body #sidebar #users li:before { content:'@'; }
-body #footer { padding-left: 60px; background-image: url(../icon.white.svg); background-size: 40px; background-repeat: no-repeat; background-position: 0px 10px; border-top: 2px solid white; padding-top: 15px; margin-top: 15px; max-width: calc(100% - 300px); min-height: 45px; line-height: 15px;}
+/* portal */
+body #portal main,
+body #portal footer { max-width: 800px; }
+body #portal #icon { display: block; width: 30px; height: 30px; background-image: url(../icon.white.svg); background-size: cover; background-repeat: no-repeat; position: absolute; bottom: 15px; right:15px; background-position: center; padding:0px }
+body #portal ul { columns:1;  }
+body #portal ul li { display:block; padding-left:5px; text-overflow: ellipsis; text-transform: lowercase;}
+body #portal ul li:before { content: attr(id) ")"; }
+body #portal ul li[data-type]::after { content:"<" attr(data-type) ">"; color:#555; }
+body #portal ul li a { line-height: 20px; padding:0px 5px; text-decoration: none;}
+body #portal ul li a:visited { color:#ccc; text-decoration: none;}
+body #portal ul li a:hover { text-decoration: underline; }
 
-@media only screen and (min-width:200px) and (max-width: 800px) {
-  body #hallway #sidebar { position: absolute;top: 0px;right: 0px;padding: 15px;width: 200px;display: none;background-color: #000; }
-  body #hallway #sidebar #channels { margin-top: 30px; }
-}
+body aside { min-width: 200px; padding: 0 15px; line-height: 16px; display: none; }
+body aside ul { margin-bottom: 15px; }
+body aside #channels li:before, body #sidebar #categories li:before { content:'/'; }
+body aside #users li:before { content:'@'; }
+body aside span.right { color: #555; float: right; }
+body aside li { text-transform: lowercase; cursor: pointer; }
 
-/* Hallway */
+/* hallway */
 
-body #hallway #entries { width: calc(100vw - 300px) !important; }
-
-body #hallway #pagination { margin: 10px; text-align: center; }
-body #hallway #pagination span { padding: 3px; margin: 2px; cursor: pointer; }
-
+body #hallway #entries { display: flex; margin-top: 35px; }
+body #hallway #entries > div { flex-grow: 1; }
+body #hallway #showbar { position: absolute;top: 0px;width: 92%;height: 50px;  background-image: url("data:image/svg+xml; utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='22'><path d='M11,4 L11,18 M4,4 L 4,18 M18,4 L18,18' stroke='%23555' fill='none' stroke-width='2' stroke-linecap='round'/></svg>");background-repeat: no-repeat;background-position: right;background-size: 25px; }
+body #hallway #hidebar { position: absolute;top: 0px;width: 100%;height: 50px;background-image: url("data:image/svg+xml; utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='22'><path d='M5,5 L17,17 M17,5 L5,17' stroke='%23555' fill='none' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/></svg>");background-repeat: no-repeat;background-position: left;background-size: 25px; }
 body #hallway .entry { line-height: 16px; display: block; position: relative; padding-left:100px; }
 body #hallway .entry .date { color: #555;display: block;float:right; margin-left:20px; padding-bottom: 16px;}
 body #hallway .entry .author { font-family: 'input_mono_medium'; position: absolute;left: 0px;  }
@@ -48,50 +48,37 @@ body #hallway .entry.highlight .author { color:#555; }
 body #hallway .entry:hover .author { color:#ccc; }
 body #hallway .entry:hover .date { color:#ccc; }
 body #hallway .entry:hover .body { color:#ccc; border-bottom-color: #555 }
-body #hallway ul { max-width: 100%; }
-body #hallway ul li:last-child { border-bottom:0px; }
+body #hallway #footer { padding-left: 60px; background-image: url(../icon.white.svg); background-size: 40px; background-repeat: no-repeat; background-position: 0px 10px; border-top: 2px solid white; padding-top: 20px; margin-top: 15px; max-width: calc(100% - 300px); min-height: 45px; line-height: 15px;}
 
-@media only screen and (min-width:200px) and (max-width: 800px) {
-  body #hallway #entries { width: 100% !important;margin-top: 30px; }
-  body #hallway #showbar { position: absolute;top: 0px;width: 92%;height: 50px;  background-image: url("data:image/svg+xml; utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='22'><path d='M11,4 L11,18 M4,4 L 4,18 M18,4 L18,18' stroke='%23555' fill='none' stroke-width='2' stroke-linecap='round'/></svg>");background-repeat: no-repeat;background-position: right;background-size: 25px; }
-  body #hallway #hidebar { position: absolute;top: 0px;width: 100%;height: 50px;background-image: url("data:image/svg+xml; utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='22'><path d='M5,5 L17,17 M17,5 L5,17' stroke='%23555' fill='none' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/></svg>");background-repeat: no-repeat;background-position: left;background-size: 25px; }
-}
+body #hallway #pagination { margin: 10px; text-align: center; }
+body #hallway #pagination span { padding: 3px; margin: 2px; cursor: pointer; }
 
-/* Portal */
-
-body #portal #icon { display: block;width: 30px;height: 30px;background-image: url(../icon.white.svg);background-size: cover;background-repeat: no-repeat;position: absolute;bottom: 15px;right:15px;background-position: center;padding:0px }
-body #portal ul { columns:3;  }
-body #portal ul li { display:block; padding-left:5px; text-overflow: ellipsis; text-transform: lowercase;}
-body #portal ul li:before { content: attr(id) ")"; }
-body #portal ul li[data-type]::after { content:"<" attr(data-type) ">"; color:#555; }
-body #portal ul li a { line-height: 20px; padding:0px 5px; text-decoration: none;}
-body #portal ul li a:visited { color:#ccc; text-decoration: none;}
-body #portal ul li a:hover { text-decoration: underline; }
-
-@media (max-width: 730px) {
-  body #portal ul li:before { display: none }
-}
-@media (max-width: 630px) {
-  body #portal ul { columns: 2 !important; }
-  body #portal ul li:before { display: none }
-}
-@media (max-width: 530px) {
-  body #portal ul { columns: 1 !important; }
-  body #portal ul li:before { display: inline }
-}
-
-/* Wiki */
-
+/* wiki */
 body #wiki { background: #ccc; color:#333; }
-body #wiki #entry { max-width: calc(100% - 230px); margin-bottom: 30px; line-height: 15px }
-body #wiki #entry a { text-decoration: underline; }
-body #wiki #sidebar { overflow-y: scroll; height: calc(100% - 15px); }
-body #wiki #sidebar a { display: inline-block; width: 120px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden; padding: 7px; }
-body #wiki #sidebar li { line-height: 7px; }
-body #wiki #sidebar li:before { display: none; }
-body #wiki #sidebar a:before { content: '/'; }
-body #wiki #sidebar a:after { content: attr(data-msgs) " msgs"; position: absolute; right: 20px; color:#555; }
-body #wiki ul.term { border-bottom: 0px; margin-bottom: 0px; padding-bottom: 0px}
-body #wiki ul.term li { margin-bottom: 5px }
-body #wiki ul.term li.name { margin-bottom: 5px }
-body #wiki ul.term li a.author { color:#555; text-decoration: none !important; }
+body #wiki main { display: flex; }
+body #wiki main { flex: 1; }
+body #wiki main { max-width: calc(100% - 230px); }
+body #wiki main h1 { font-size: 1.3em; margin: 5px 0; font-weight: bold; }
+body #wiki main div.related { border-bottom: 1px solid white; margin-bottom: 10px; }
+body #wiki #main { width: 100%; }
+body #wiki #main ul li { line-height: 15px; }
+body #wiki aside { min-width: 220px; }
+body #wiki aside  { overflow-y: scroll; height: calc(100% - 15px); position: absolute; right: 0;}
+body #wiki aside a { display: inline-block; width: 135px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden; padding: 7px; }
+body #wiki aside li { line-height: 7px; }
+body #wiki aside li:before { display: none; }
+body #wiki aside a:before { content: '/'; }
+body #wiki aside a:after { content: attr(data-msgs) " msgs"; position: absolute; right: 20px; color:#555; }
+body #wiki ul.term { margin-bottom: 15px; }
+body #wiki ul.term li.name { margin-bottom: 5px; }
+body #wiki #footer { padding-left: 60px; background-image: url(../icon.white.svg); background-size: 40px; background-repeat: no-repeat; background-position: 0px 10px; border-top: 2px solid white; padding-top: 22px; margin-top: 15px; max-width: calc(100% - 300px); min-height: 45px; line-height: 15px;}
+
+@media (min-width: 630px) {
+  body aside { display: block; }
+  body #portal ul { columns: 3;}
+  body #hallway #entries { margin-top: 0; }
+  body #hallway #showbar { display: none; }
+  body #hallway #hidebar { display: none; }
+  body #wiki footer { margin-right: 225px; }
+}
+

--- a/links/main.css
+++ b/links/main.css
@@ -58,6 +58,7 @@ body #wiki { background: #ccc; color:#333; }
 body #wiki main { display: flex; }
 body #wiki main { flex: 1; }
 body #wiki main { max-width: calc(100% - 230px); }
+body #wiki main a { text-decoration: underline; }
 body #wiki main h1 { font-size: 1.3em; margin: 5px 0; font-weight: bold; }
 body #wiki main div.related { border-bottom: 1px solid white; margin-bottom: 10px; }
 body #wiki #main { width: 100%; }

--- a/links/main.css
+++ b/links/main.css
@@ -61,7 +61,7 @@ body #wiki main { max-width: calc(100% - 230px); }
 body #wiki main h1 { font-size: 1.3em; margin: 5px 0; font-weight: bold; }
 body #wiki main div.related { border-bottom: 1px solid white; margin-bottom: 10px; }
 body #wiki #main { width: 100%; }
-body #wiki #main a { text-decoration: underline; }
+body #wiki #main a:hover { text-decoration: underline; }
 body #wiki #main ul li { line-height: 15px; }
 body #wiki aside { min-width: 220px; }
 body #wiki aside  { overflow-y: scroll; height: calc(100% - 15px); position: absolute; right: 0;}

--- a/scripts/hallway.js
+++ b/scripts/hallway.js
@@ -14,24 +14,21 @@ function Hallway (sites) {
   this.finder = { filter: filterAndPage[0].trim().replace('#', ''), page: filterAndPage[1] || 1 }
   this.cache = null
 
-  this._entries = document.createElement('div')
-  this._entries.id = 'entries'
-  this._sidebar = document.createElement('div')
-  this._sidebar.id = 'sidebar'
-  this._footer = document.createElement('p')
+  this._main = document.createElement('main')
+  this._main.id = 'entries'
+  this._footer = document.createElement('footer')
   this._footer.id = 'footer'
-  this._footer.innerHTML = `The <strong>Hallway</strong> is a decentralized forum, to join the conversation, add a <a href="https://github.com/XXIIVV/webring#joining-the-hallway">feed:</a> field to your entry in the <a href="https://github.com/XXIIVV/Webring/">webring</a>.`
+  this._footer.innerHTML = `<p>The <strong>Hallway</strong> is a decentralized forum, to join the conversation, add a <a href="https://github.com/XXIIVV/webring#joining-the-hallway">feed:</a> field to your entry in the <a href="https://github.com/XXIIVV/Webring/">webring</a>.</p>`
 
   this.install = function (host) {
-    this._el.appendChild(this._entries)
-    this._el.appendChild(this._sidebar)
+    this._el.appendChild(this._main)
     this._el.appendChild(this._footer)
     host.appendChild(this._el)
     this.findFeeds()
   }
 
   this.start = function () {
-    this._entries.innerHTML = 'Loading..'
+    this._main.innerHTML = 'Loading..'
     this.fetchFeeds()
   }
 
@@ -43,27 +40,31 @@ function Hallway (sites) {
     const tags = this.findTags(localEntries)
     const relevantEntries = localEntries.filter(val => !this.finder.filter || (val.author === this.finder.filter || val.channel === this.finder.filter || val.tags.includes(this.finder.filter)))
 
-    this._entries.innerHTML = `
-    <ul>
-      ${localEntries.filter((val) => !this.finder.filter || (val.author === this.finder.filter || val.channel === this.finder.filter || val.tags.includes(this.finder.filter))).filter((_, id) => id < Number(this.finder.page) * 20 && id >= (Number(this.finder.page) - 1) * 20).reduce((acc, val) => acc + this.templateEntry(val) + '\n', '')}
-    </ul>
-    <div id='pagination'>
-      ${[...Array(Math.ceil(relevantEntries.length / 20)).keys()].reduce((acc, num) => `${acc}<span class='${Number(hallway.finder.page) === num + 1 ? 'selected' : ''}' onclick='filter("${this.finder.filter}^${num + 1}")'>${num + 1}</span>`, '')}
-    </div>
-    <a id='showbar' onclick="toggleVisibility('sidebar');"></a>`
+    const mainHtml = `
+    <div><ul>
+        ${localEntries.filter((val) => !this.finder.filter || (val.author === this.finder.filter || val.channel === this.finder.filter || val.tags.includes(this.finder.filter))).filter((_, id) => id < Number(this.finder.page) * 20 && id >= (Number(this.finder.page) - 1) * 20).reduce((acc, val) => acc + this.templateEntry(val) + '\n', '')}
+      </ul>
+      <div id='pagination'>
+        ${[...Array(Math.ceil(relevantEntries.length / 20)).keys()].reduce((acc, num) => `${acc}<span class='${Number(hallway.finder.page) === num + 1 ? 'selected' : ''}' onclick='filter("${this.finder.filter}^${num + 1}")'>${num + 1}</span>`, '')}
+      </div>
+      <a id='showbar' onclick="toggleVisibility('aside');"></a></div>`
 
-    this._sidebar.innerHTML = `
-    <a id='hidebar' onclick="toggleVisibility('sidebar');"></a>
-    <ul id='channels'>
-      <li onclick='filter("")' class='${hallway.finder.filter === '' ? 'selected' : ''}'><a href='#'>hallway <span class='right'>${localEntries.length}</span></a></li>
-      ${Object.keys(channels).slice(0, 15).reduce((acc, val) => acc + `<li onclick='filter("${val}")' class='${hallway.finder.filter === val ? 'selected' : ''}'><a href='#${val}'>${val} <span class='right'>${channels[val]}</span></a></li>\n`, '')}
-    </ul>
-    <ul id='users'>
-      ${Object.keys(users).slice(0, 15).reduce((acc, val) => acc + `<li onclick='filter("${val}")' class='${hallway.finder.filter === val ? 'selected' : ''}' href='#${val}'>${val} <span class='right'>${users[val]}</span></li>\n`, '')}
-    </ul>
-    <ul id='tags'>
-      ${Object.keys(tags).slice(0, 15).reduce((acc, val) => acc + `<li onclick='filter("${val}")' class='${hallway.finder.filter === val ? 'selected' : ''}' href='#${val}'>#${val} <span class='right'>${tags[val]}</span></li>\n`, '')}
-    </ul>`
+    const aside = `
+    <aside id='aside'>
+      <a id='hidebar' onclick="toggleVisibility('aside');"></a>
+      <ul id='channels'>
+        <li onclick='filter("")' class='${hallway.finder.filter === '' ? 'selected' : ''}'><a href='#'>hallway <span class='right'>${localEntries.length}</span></a></li>
+        ${Object.keys(channels).slice(0, 15).reduce((acc, val) => acc + `<li onclick='filter("${val}")' class='${hallway.finder.filter === val ? 'selected' : ''}'><a href='#${val}'>${val} <span class='right'>${channels[val]}</span></a></li>\n`, '')}
+      </ul>
+      <ul id='users'>
+        ${Object.keys(users).slice(0, 15).reduce((acc, val) => acc + `<li onclick='filter("${val}")' class='${hallway.finder.filter === val ? 'selected' : ''}' href='#${val}'>${val} <span class='right'>${users[val]}</span></li>\n`, '')}
+      </ul>
+      <ul id='tags'>
+        ${Object.keys(tags).slice(0, 15).reduce((acc, val) => acc + `<li onclick='filter("${val}")' class='${hallway.finder.filter === val ? 'selected' : ''}' href='#${val}'>#${val} <span class='right'>${tags[val]}</span></li>\n`, '')}
+        </ul>
+    </aside>`
+
+    this._main.innerHTML = `${mainHtml}${aside}`
 
     if (feeds) {
       this.cache = feeds

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -16,19 +16,22 @@ function Portal (sites) {
   }
 
   function _directory (sites) {
-    return `
-    <ul>${sites.reduce( (acc, site, id) =>
-          `${acc}<li ${site.type ? `data-type="${site.type}"` : ''} id='${id}'><a href='${site.url}'>${_name(site)}</a></li>`
-    , '')}</ul>\n${_readme()}${_buttons()}`
+    const listItems= sites.reduce((acc, site, id) => `${acc}<li ${_type(site)} id='${id}'><a href='${site.url}'>${_name(site)}</a></li>`, '')
+    return `<main><ul>${listItems}</ul></main><footer>${_readme()}${_buttons()}</footer>`
   }
 
   function _name (site) {
     return site.title || `${site.url.split('//')[1]}`
   }
 
+  function _type (site) {
+     return site.type ? `data-type="${site.type}"` : ''
+  }
+
   function _redirect (site) {
-    return `<p id='footer'>Redirecting to <a href="${site.url}">${site.url}</a></p><meta http-equiv="refresh" content="3; url=${site.url}">
-    <p class='buttons'><a href='#' onClick="portal.reload('')">Directory</a> | <a href='#${site.url}' onClick="portal.reload('random')">Skip</a> | <a href='#random' onClick="portal.reload('random')">Random</a> | <a href='https://github.com/XXIIVV/webring'>Information</a> <a id='icon'  href='#random' onClick="portal.reload('random')"></a></p>`
+    return `<main><p>Redirecting to <a href="${site.url}">${site.url}</a></p></main>
+      <meta http-equiv="refresh" content="3; url=${site.url}">
+      <footer><p class='buttons'><a href='#' onClick="portal.reload('')">Directory</a> | <a href='#${site.url}' onClick="portal.reload('random')">Skip</a> | <a href='#random' onClick="portal.reload('random')">Random</a> | <a href='https://github.com/XXIIVV/webring'>Information</a> <a id='icon'  href='#random' onClick="portal.reload('random')"></a></p>`
   }
 
   //
@@ -52,17 +55,12 @@ function Portal (sites) {
   this.locate = function () {
     const hash = window.location.hash.replace('#', '').trim()
 
-    if (hash == 'random') {
+    if (hash === 'random') {
       return Math.floor(Math.random() * this.sites.length)
+    } else {
+      const id = sites.findIndex(site => site.url.indexOf(hash) > -1)
+      return id > -1 ? parseInt(id) : -1
     }
-
-    for (const id in this.sites) {
-      const site = this.sites[id]
-      if (site.url.indexOf(hash) > -1) {
-        return parseInt(id)
-      }
-    }
-    return -1
   }
 
   this.next = function (loc = this.locate()) {

--- a/scripts/wiki.js
+++ b/scripts/wiki.js
@@ -105,7 +105,7 @@ const Wiki = sites => {
     } else {
       const html = `Click a /topic to get started, or try a <a href='#${randomTerm()}'>random page</a>`
       const stats = `The wiki contains ${terms.size} terms in ${Object.keys(entries).length} categories, from ${authors.size} authors.`
-      main.innerHTML = `${html}<br />${stats}`
+      main.innerHTML = `<h1>WIKI</h1>${html}<br />${stats}`
     }
 
     const homeCat = `<li class='${selected(key, '')}'>

--- a/scripts/wiki.js
+++ b/scripts/wiki.js
@@ -40,6 +40,11 @@ const Wiki = sites => {
     ? 'selected'
     : ''
 
+  const randomTerm = () => {
+    const keys = Object.keys(entries)
+    return keys[Math.floor(Math.random() * keys.length)]
+  }
+
   const formatSideBarCat = (key, entries) => (currentHtml, cat) => {
     const catLength = Object.keys(entries[cat]).length
     const newHtml = `<li class='${selected(key, cat)}'}'>
@@ -98,7 +103,7 @@ const Wiki = sites => {
         : ''
       main.innerHTML = `<div class='related'><h1>${key}</h1>${relatedHtml}</div>${items}`
     } else {
-      const html = `Click a /topic to get started, or try a random page`
+      const html = `Click a /topic to get started, or try a <a href='#${randomTerm()}'>random page</a>`
       const stats = `The wiki contains ${terms.size} terms in ${Object.keys(entries).length} categories, from ${authors.size} authors.`
       main.innerHTML = `${html}<br />${stats}`
     }

--- a/scripts/wiki.js
+++ b/scripts/wiki.js
@@ -1,154 +1,136 @@
 'use strict'
 
-function Wiki (sites) {
-  const feeds = {}
-  this.sites = sites
-  this._el = document.createElement('div')
-  this._el.id = 'wiki'
-  this._sidebar = document.createElement('div')
-  this._sidebar.id = 'sidebar'
-  this._categories = document.createElement('ul')
-  this._categories.id = 'categories'
-  this._entry = document.createElement('div')
-  this._entry.id = 'entry'
+const Wiki = sites => {
+  const entries = {}
+  const main = document.getElementById('main')
+  const aside = document.getElementById('aside')
+  const authors = new Set()
+  const terms = new Set()
 
-  this._footer = document.createElement('p')
-  this._footer.id = 'footer'
-  this._footer.innerHTML = `The <strong>Wiki</strong> is a decentralized encyclopedia, to join the conversation, add a <a href="https://github.com/XXIIVV/webring#joining-the-wiki">wiki:</a> field to your entry in the <a href="https://github.com/XXIIVV/Webring/">webring</a>.`
-
-  this.loc = ''
-  this.byName = {}
-  this.byCat = {}
-  this.byAuthor = {}
-
-  this.install = (host) => {
-    this._el.appendChild(this._entry)
-    this._sidebar.appendChild(this._categories)
-    this._el.appendChild(this._sidebar)
-    this._el.appendChild(this._footer)
-    host.appendChild(this._el)
-    this.fetch()
-  }
-
-  this.start = () => {
-    this._entry.innerHTML = 'Loading..'
-  }
-
-  this.refresh = () => {
-    // Main
-    if (this.loc) {
-      if (this.byCat[this.loc]) {
-        const formatHtml = (entries, entry) => `${entries} ${this.templateTerm(entry.name, this.byName[entry.name])}<br />`
-        const html = this.byCat[this.loc].reduce(formatHtml, '')
-        this._entry.innerHTML = html
-      } else if (this.byName[this.loc]) {
-        const html = `${this.templateTerm(this.loc, this.byName[this.loc])}<br />${this.templateRelated(this.loc)}`
-        this._entry.innerHTML = html
-      } else {
-        const html = `Unknown: ${this.loc}. Return <a href='#'>home</a>, or try a <a href='${this.random()}'>random page</a>.`
-        this._entry.innerHTML = html
-      }
+  const storeEntry = (author, url, parent, cat, entry) => {
+    if (!(parent in entries)) {
+      entries[parent] = {}
+      entries[parent][cat] = [{ entry, author, url }]
+    } else if (!(cat in entries[parent])) {
+      entries[parent][cat] = [{ entry, author, url }]
     } else {
-      this._entry.innerHTML = `Click a /topic to get started, or try a <a href='#${this.random()}'>random page</a>.<br />The wiki contains ${Object.keys(this.byName).length} terms, in ${Object.keys(this.byCat).length} categories, by ${Object.keys(this.byAuthor).length} authors.`
+      entries[parent][cat].push({ entry, author, url })
     }
-    // Sidebar
-    this._categories.innerHTML = Object.keys(this.byCat).reduce((acc, id) =>
-      { return this.byCat[id].length > 5
-          ? `${acc}<li ${wiki.at(id) ? 'class="selected"' : ''}>
-            <a href='#${id}' data-msgs='${this.byCat[id].length}'>${id}</a>
-            </li>`
-          : acc
-      } , `<li ${wiki.at() ? 'class="selected"' : ''}>
-           <a href='#' data-msgs='${Object.keys(this.byName).length}'>home</a>
-           </li>`
-    )
+    terms.add(cat)
+    authors.add(author)
   }
 
-  this.go = () => {
-    this.loc = decodeURIComponent( window.location.hash.substr(1) ).toUpperCase()
-    this.refresh()
+  const storeEntries = (author, url, parent, entries) => {
+    Array.isArray(entries)
+      ? storeEntry(author, url, parent, 'list-definitions', entries)
+      : Object.keys(entries).forEach(entry => storeEntry(author, url, parent, entry, entries[entry]))
   }
 
-  this.at = (q = '') => {
-    return this.loc.toUpperCase() === q.toUpperCase() || (this.cat(this.loc).toUpperCase() === q.toUpperCase() && q !== '')
+  const transform = (author, url, ndtl) => {
+    Object.keys(ndtl).forEach(cat => storeEntries(author, url, cat, ndtl[cat]))
   }
 
-  this.random = () => {
-    const keys = Object.keys(this.byCat)
-    return keys[Math.floor(Math.random() * keys.length)]
-  }
-
-  this.related = (name) => {
-    return this.byCat[this.cat(name)]
-  }
-
-  this.cat = (name) => {
-    return this.byName[name] ? this.byName[name][0].cat : ''
-  }
-
-  this.templateRelated = (name) => {
-    const relatedWords = this.related(name)
-    const html = `<ul class='col3'>${relatedWords.reduce( (acc, item, id) =>
-      { return `${acc}<li ${wiki.at(item.name) ? 'class="selected"' : ''}>
-        <a href='#${item.name.toLowerCase()}'>${item.name.toLowerCase()}</a>
-        </li>`
-      }, '') }
-      </ul>`
-    return html
-  }
-
-  this.templateTerm = (name, entries) => {
-    const formatEntry = (acc, entry) => {
-      if (typeof entry.value === 'string') {
-        return `${acc}<li>${entry.value}<a class='author' target='_blank' href='${entry.origin.url}'> — @${entry.origin.author}</a></li>`
-      } else {
-        const listItems = entry.value.reduce((items, item) => `${items}<li>${item}</li>`, '')
-        return `${acc}<li><ul>${listItems}<a class='author' target='_blank' href='${entry.origin.url}'> — @${entry.origin.author}</a></ul></li>`
-      }
-    }
-
-    const htmlEntries = entries.reduce(formatEntry, '')
-    return `<ul class="term"><li class="name"><strong>${name.toLowerCase()}</strong></li>${htmlEntries}</ul>`
-  }
-
-  this.fetch = () => {
-    console.log('Wiki', 'Fetching..')
-    for (const site of sites) {
-      if (!site.wiki || !site.author) { continue }
-      fetch(site.wiki, { cache: 'no-store' }).then(x => x.text()).then((content) => {
-        this.parse(site, content)
-        this.refresh(feeds)
-      }).catch((err) => {
-        console.warn(`${site.wiki}`, err)
-      })
-    }
-  }
-
-  this.add = (name, value, cat, origin) => {
-    this.byName[name] = this.byName[name] || []
-    this.byName[name].push({ name, value, cat, origin })
-
-    this.byCat[cat] = this.byCat[cat] || []
-    this.byCat[cat].push({ name, value, cat, origin })
-
-    this.byAuthor[origin.author] = this.byAuthor[origin.author] || []
-    this.byAuthor[origin.author].push({ name, value, cat, origin })
-  }
-
-  this.parse = (site, content) => {
+  const parse = (site, content) => {
     console.log('Wiki', 'Parsing ' + site.wiki)
-    const cats = indental(content)
-    for (const cat in cats) {
-      const terms = cats[cat]
-      for (const name in terms) {
-        this.add(name, terms[name], cat, site)
-      }
-    }
+    const ndtl = indental(content)
+    transform(site.author, site.url, ndtl)
   }
 
-  String.prototype.toUrl = function () { return this.toLowerCase().replace(/ /g, '+').replace(/[^0-9a-z+:\-./~]/gi, '').trim() }
+  const selected = (key, category) => key.toLowerCase() === category.toLowerCase()
+    ? 'selected'
+    : ''
 
-  window.onload = this.go
-  window.onhashchange = this.go
+  const formatSideBarCat = (key, entries) => (currentHtml, cat) => {
+    const catLength = Object.keys(entries[cat]).length
+    const newHtml = `<li class='${selected(key, cat)}'}'>
+                      <a href='#${cat}' data-msgs='${catLength}'>${cat.toLowerCase()}</a>
+                     </li>`
+    return `${currentHtml}${newHtml}`
+  }
+
+  const formatEntry = (definitions, definition) => {
+    const formatEntryList = entryList => entryList.reduce((items, item) => `${items}<li>${item}</li>`, '')
+
+    const newHtml = typeof definition.entry === 'string'
+      ? `<li>${definition.entry}
+          <a class='author' target='_blank' href='${definition.url}'> - @${definition.author}</a>
+        </li>`
+      : `<li><ul>${formatEntryList(definition.entry)}
+          <a class='author' target='_blank' href='${definition.url}'> — @${definition.author}</a>
+        </ul></li>`
+
+    return `${definitions}${newHtml}`
+  }
+
+  const formatEntries = entries => (currentHtml, category) => {
+    const definitions = entries[category].reduce(formatEntry, '')
+    const title = category === 'list-definitions'
+      ? ''
+      : `<li class='name'><strong>${category.toLowerCase()}</strong></li>`
+    return `${currentHtml}<ul class='term'>${title}${definitions}</ul>`
+  }
+
+  const findRelated = key => {
+    const searchOtherCategories = entry => {
+      return Object.keys(entries)
+        .filter(category => Object.keys(entries[category]).some(otherCat => otherCat === entry))
+    }
+
+    const foundMatches = Object.keys(entries[key])
+      .filter(entry => entry !== 'list-definitions')
+      .map(searchOtherCategories)
+    const flattened = [].concat.apply([], foundMatches)
+    return Array.from(new Set(flattened)).filter(related => related !== key)
+  }
+
+  const formatRelated = (allRelated, relatedCategory) => {
+    const newHtml = `<span><a href='#${relatedCategory}'>/${relatedCategory.toLowerCase()}</a> </span>`
+    return `${allRelated}${newHtml}`
+  }
+
+  const refresh = key => {
+    if (key) {
+      if (entries[key] === undefined) return
+      const items = Object.keys(entries[key]).sort().reduce(formatEntries(entries[key]), '')
+      const relatedCategories = findRelated(key)
+      const relatedHtml = relatedCategories.length > 0
+        ? relatedCategories.reduce(formatRelated, 'Related categories: ')
+        : ''
+      main.innerHTML = `<div class='related'><h1>${key}</h1>${relatedHtml}</div>${items}`
+    } else {
+      const html = `Click a /topic to get started, or try a random page`
+      const stats = `The wiki contains ${terms.size} terms in ${Object.keys(entries).length} categories, from ${authors.size} authors.`
+      main.innerHTML = `${html}<br />${stats}`
+    }
+
+    const homeCat = `<li class='${selected(key, '')}'>
+                      <a href='#' data-msgs='${terms.size}'>home</a>
+                    </li>`
+    const cats = Object.keys(entries).sort().reduce(formatSideBarCat(key, entries), homeCat)
+    aside.innerHTML = `<ul>${cats}</ul>`
+  }
+
+  return {
+    initialize: hash => {
+      console.log('Wiki', 'Fetching...')
+      sites.filter(site => site.wiki && site.author).forEach(site => {
+        fetch(site.wiki, { cache: 'no-store' }).then(x => x.text()).then(content => {
+          parse(site, content)
+          refresh(stripHash(hash))
+        }).catch((err) => {
+          console.warn(`${site.wiki}`, err)
+        })
+      })
+    },
+    refresh: key => { refresh(key) }
+  }
 }
 
+const stripHash = hash => {
+  const decoded = decodeURIComponent(hash)
+  return decoded.charAt(0) === '#' ? decoded.substring(1) : decoded
+}
+
+window.addEventListener('hashchange', () => {
+  wiki.refresh(stripHash(window.location.hash).toUpperCase())
+})

--- a/scripts/wiki.js
+++ b/scripts/wiki.js
@@ -58,7 +58,7 @@ const Wiki = sites => {
 
     const newHtml = typeof definition.entry === 'string'
       ? `<li>${definition.entry}
-          <a class='author' target='_blank' href='${definition.url}'> - @${definition.author}</a>
+          - <a class='author' target='_blank' href='${definition.url}'> @${definition.author}</a>
         </li>`
       : `<li><ul>${formatEntryList(definition.entry)}
           <a class='author' target='_blank' href='${definition.url}'> — @${definition.author}</a>

--- a/wiki.html
+++ b/wiki.html
@@ -11,10 +11,18 @@
   <title>Wiki</title>
 </head>
 <body>
+  <div id="wiki">
+    <main>
+      <div id="main"></div>
+      <aside id="aside"></aside>
+    </main>
+    <footer id="footer">
+      <p>The <strong>Wiki</strong> is a decentralized encyclopedia, to join the conversation, add a <a href="https://github.com/XXIIVV/webring#joining-the-wiki">wiki:</a> field to your entry in the <a href="https://github.com/XXIIVV/Webring/">webring</a>.</p>
+    </footer>
+  </div>
   <script>
-    const wiki = new Wiki(sites);
-    wiki.install(document.body);
-    wiki.start();
+    const wiki = Wiki(sites)
+    wiki.initialize(window.location.hash)
   </script>
 </body>
 </html>


### PR DESCRIPTION
Alright, so this is a lot of changes, and I'll do my best to explain why I did what I did.

*Wiki*

This is by far the biggest one, and it's sort almost an entire re-write.

- Changed the constructor function approach to a factory function.

This is a bit of a personal opinion, but I find constructor functions have quite a bit of boilerplate code that isn't always necessary, especially when you aren't concerned about getting new objects when creating multiple/lots. In this case, we are just creating one. I find that using a factory function instead is still similar, but gets rid of the `this` everywhere.

- Allow lists to be shown both at the top level of a category and under a key. This will better allow for people to use lists either under a category or under a definition. This closes #244. As a bonus, it also allows for one author to have a list under a category, and another to have a key value pair.

- Add in a `Relate categories` section under the category title. I chose to do this rather than displaying the same definition under a key that may be shared from two different categories. The reason is that for me personally I'd rather just go to that page and see that definition within the context of that category. The way I implemented this closes #234. I also get why you may want both definitions of the same word display even if it's from another category, but it currently isn't behaving correctly, showing duplicates, and not highlighting the related category correctly. I had a really hard time following the flow that existed before, and I found that having one solid data structure that we interact with was much easier instead of a by author one, by category, etc.

- Refactoring of really long lines into smaller functions
This one is a bit picky, but I really dislike really long lines in my code. It makes it really hard to follow and horizontal scrolling just sucks. This caused me to really break things apart. I made sure to separate all the templating logic from the parsing logic. I actually think this makes the entire thing a bit easier to read and also address the recent comment in #234 about being hard to follow the logic.

*Style changes*

- Changed the index.html to the way it used to be with a nicer footer. Somewhere along the line that got screwed up.

- Changed around the multiple media queries to only have one media query and achieve the same goal

*More semantic html*

This closes #242
I did my best to add in footer elements and such in each view, and in the wiki I decided to just fully move some of the html that doesn't change right into the actual html document. I don't see the point to create an element, give that element text, and then attach that element to the dom, and then never change it. Why not just put it in as html and not touch it. I opted for this. If we like this approach, I think we could also do it in the hallway and reduce the amount of JS that is needed to display it the same way.

All in all, I hope this makes things a bit more clear and it does reduce the code a bit while adding in features. I have a few snapshot below to illustrate the changes.

Old:
![image](https://user-images.githubusercontent.com/13974112/62820810-26006b80-bb6a-11e9-97fe-47642c415cf6.png)

New:
![image](https://user-images.githubusercontent.com/13974112/62820813-331d5a80-bb6a-11e9-90d0-30cb40919998.png)

Old:
![image](https://user-images.githubusercontent.com/13974112/62820818-4c260b80-bb6a-11e9-9cf2-fbd51f6a45b3.png)

New:
![image](https://user-images.githubusercontent.com/13974112/62820845-ceaecb00-bb6a-11e9-8660-719c71dedff8.png)


