### PR TITLE
Feature: Add a progress indicator to the wiki

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -77,8 +77,10 @@ body #wiki #footer { padding-left: 60px; background-image: url(../icon.white.svg
 /* progress indicator */
 body #progress { color: #777; }
 body #progress .busy { cursor: wait; }
-body #progress progress { -webkit-appearance: none; -moz-appearance: none; appearance: none; background: #ccc; width: 100px; height: 5px; border: 1px solid #777; }
-body #progress progress::-webkit-progress-bar, body progress::-moz-progress-bar { background: #777; }
+body #progress progress { -webkit-appearance: none; -moz-appearance: none; appearance: none; background: #ccc; color: #777; width: 100px; height: 5px; border: 1px solid #777; box-sizing: border-box; }
+body #progress progress::-webkit-progress-bar { background: #ccc; }
+body #progress progress::-webkit-progress-value { background: #777; } /* warning: don't merge this with -moz-progress-bar below, it will break in webkit! */
+body #progress progress::-moz-progress-bar { background: #777; }
 
 @media (min-width: 630px) {
   body aside { display: block; }

--- a/links/main.css
+++ b/links/main.css
@@ -74,6 +74,12 @@ body #wiki ul.term { margin-bottom: 15px; }
 body #wiki ul.term li.name { margin-bottom: 5px; }
 body #wiki #footer { padding-left: 60px; background-image: url(../icon.white.svg); background-size: 40px; background-repeat: no-repeat; background-position: 0px 10px; border-top: 2px solid white; padding-top: 22px; margin-top: 15px; max-width: calc(100% - 300px); min-height: 45px; line-height: 15px;}
 
+/* progress indicator */
+body #progress { color: #777; }
+body #progress .busy { cursor: wait; }
+body #progress progress { -webkit-appearance: none; -moz-appearance: none; appearance: none; background: #ccc; width: 100px; height: 5px; border: 1px solid #777; }
+body #progress progress::-webkit-progress-bar, body progress::-moz-progress-bar { background: #777; }
+
 @media (min-width: 630px) {
   body aside { display: block; }
   body #portal ul { columns: 3;}

--- a/scripts/progress.js
+++ b/scripts/progress.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const Progress = keys => {
+  const allKeys = new Set(keys.filter(key => key))
+  const loadedKeys = new Set()
+  const failedKeys = new Set()
+
+  const done = () => loadedKeys.size === allKeys.size
+
+  const className = () => done() ? 'done' : 'busy'
+
+  const formatPercentLoaded = () => `
+    ${Math.round(100 * loadedKeys.size / Math.max(allKeys.size, 1))}% loaded
+  `
+
+  const formatFailureCount = () => failedKeys.size === 0
+    ? ''
+    : `(${failedKeys.size} failed)`
+
+  const formatProgress = () => done()
+    ? ''
+    : `<p><progress value='${loadedKeys.size}' max='${allKeys.size}'></progress></p>`
+
+  const render = () => `
+    <div class='${className()}'>
+      <p>${formatPercentLoaded()} ${formatFailureCount()}</p>
+      ${formatProgress()}
+    </div>
+  `
+
+  const didLoad = (key, success) => new Promise((resolve, reject) => {
+    if (allKeys.has(key)) {
+      loadedKeys.add(key)
+      if (!success) failedKeys.add(key)
+      return resolve()
+    } else {
+      return reject()
+    }
+  })
+
+  return {
+    success: key => didLoad(key, true),
+    failure: key => didLoad(key, false),
+    done,
+    render,
+  }
+}

--- a/scripts/wiki.js
+++ b/scripts/wiki.js
@@ -4,6 +4,8 @@ const Wiki = sites => {
   const entries = {}
   const main = document.getElementById('main')
   const aside = document.getElementById('aside')
+  const progress = document.getElementById('progress')
+  const progressCounter = Progress(sites.map(site => site.wiki))
   const authors = new Set()
   const terms = new Set()
 
@@ -115,15 +117,22 @@ const Wiki = sites => {
     aside.innerHTML = `<ul>${cats}</ul>`
   }
 
+  const refreshProgress = () => {
+    progress.innerHTML = progressCounter.render()
+  }
+
   return {
     initialize: hash => {
       console.log('Wiki', 'Fetching...')
+      refreshProgress()
       sites.filter(site => site.wiki && site.author).forEach(site => {
         fetch(site.wiki, { cache: 'no-store' }).then(x => x.text()).then(content => {
           parse(site, content)
           refresh(stripHash(hash))
+          progressCounter.success(site.wiki).then(refreshProgress)
         }).catch((err) => {
           console.warn(`${site.wiki}`, err)
+          progressCounter.failure(site.wiki).then(refreshProgress)
         })
       })
     },

--- a/wiki.html
+++ b/wiki.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="links/fonts.css"/>
   <link rel="stylesheet" type="text/css" href="links/main.css"/>
+  <script src="scripts/progress.js"></script>
   <script src="scripts/wiki.js"></script>
   <script src="scripts/sites.js"></script>
   <script src="scripts/indental.js"></script>
@@ -18,6 +19,7 @@
     </main>
     <footer id="footer">
       <p>The <strong>Wiki</strong> is a decentralized encyclopedia, to join the conversation, add a <a href="https://github.com/XXIIVV/webring#joining-the-wiki">wiki:</a> field to your entry in the <a href="https://github.com/XXIIVV/Webring/">webring</a>.</p>
+      <div id="progress"></div>
     </footer>
   </div>
   <script>


### PR DESCRIPTION
This shows a progress indicator in the footer on the Wiki, so you can tell when everything's loaded. I've tried to make it general enough that the same code could be run on the Hallway.

<img width="403" alt="Screenshot: 88% loaded" src="https://user-images.githubusercontent.com/14365947/62827928-193d4f80-bc1e-11e9-8efb-5107e603cf32.png">

<img width="393" alt="Screenshot: 100% loaded" src="https://user-images.githubusercontent.com/14365947/62827929-193d4f80-bc1e-11e9-9e6a-c0e5f90e515c.png">
