### PR TITLE
add in nav, fix opml console err

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -29,7 +29,6 @@ body aside span.right { color: #555; float: right; }
 body aside li { text-transform: lowercase; cursor: pointer; }
 
 /* hallway */
-
 body #hallway #entries { display: flex; margin-top: 35px; }
 body #hallway #entries > div { flex-grow: 1; }
 body #hallway #showbar { position: absolute;top: 0px;width: 92%;height: 50px;  background-image: url("data:image/svg+xml; utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='22'><path d='M11,4 L11,18 M4,4 L 4,18 M18,4 L18,18' stroke='%23555' fill='none' stroke-width='2' stroke-linecap='round'/></svg>");background-repeat: no-repeat;background-position: right;background-size: 25px; }
@@ -48,7 +47,7 @@ body #hallway .entry.highlight .author { color:#555; }
 body #hallway .entry:hover .author { color:#ccc; }
 body #hallway .entry:hover .date { color:#ccc; }
 body #hallway .entry:hover .body { color:#ccc; border-bottom-color: #555 }
-body #hallway #footer { padding-left: 60px; background-image: url(../icon.white.svg); background-size: 40px; background-repeat: no-repeat; background-position: 0px 10px; border-top: 2px solid white; padding-top: 20px; margin-top: 15px; max-width: calc(100% - 300px); min-height: 45px; line-height: 15px;}
+body #hallway #footer { padding-left: 60px; background-image: url(../icon.white.svg); background-size: 40px; background-repeat: no-repeat; background-position: 0px 20px; border-top: 2px solid white; padding-top: 20px; margin-top: 15px; min-height: 45px; line-height: 15px;}
 
 body #hallway #pagination { margin: 10px; text-align: center; }
 body #hallway #pagination span { padding: 3px; margin: 2px; cursor: pointer; }
@@ -57,10 +56,10 @@ body #hallway #pagination span { padding: 3px; margin: 2px; cursor: pointer; }
 body #wiki { background: #ccc; color:#333; }
 body #wiki main { display: flex; }
 body #wiki main { flex: 1; }
-body #wiki main { max-width: calc(100% - 230px); }
 body #wiki main h1 { font-size: 1.3em; margin: 5px 0; font-weight: bold; }
 body #wiki main div.related { border-bottom: 1px solid white; margin-bottom: 10px; }
 body #wiki #main { width: 100%; }
+body #wiki #main > a { text-decoration: underline; }
 body #wiki #main a:hover { text-decoration: underline; }
 body #wiki #main ul li { line-height: 15px; }
 body #wiki aside { min-width: 220px; }
@@ -72,7 +71,7 @@ body #wiki aside a:before { content: '/'; }
 body #wiki aside a:after { content: attr(data-msgs) " msgs"; position: absolute; right: 20px; color:#555; }
 body #wiki ul.term { margin-bottom: 15px; }
 body #wiki ul.term li.name { margin-bottom: 5px; }
-body #wiki #footer { padding-left: 60px; background-image: url(../icon.white.svg); background-size: 40px; background-repeat: no-repeat; background-position: 0px 10px; border-top: 2px solid white; padding-top: 12px; margin-top: 15px; max-width: calc(100% - 300px); min-height: 45px; line-height: 15px;}
+body #wiki #footer { padding-left: 60px; background-image: url(../icon.white.svg); background-size: 40px; background-repeat: no-repeat; background-position: 0px 18px; border-top: 2px solid white; padding-top: 12px; margin-top: 15px; min-height: 45px; line-height: 15px;}
 
 /* progress indicator */
 body #progress { color: #777; }
@@ -88,6 +87,8 @@ body #progress progress::-moz-progress-bar { background: #777; }
   body #hallway #entries { margin-top: 0; }
   body #hallway #showbar { display: none; }
   body #hallway #hidebar { display: none; }
-  body #wiki footer { margin-right: 225px; }
+  body #hallway #footer { max-width: calc(100% - 300px); }
+  body #wiki main { max-width: calc(100% - 230px); }
+  body #wiki footer { margin-right: 225px; max-width: calc(100% - 300px); }
 }
 

--- a/scripts/hallway.js
+++ b/scripts/hallway.js
@@ -18,7 +18,9 @@ function Hallway (sites) {
   this._main.id = 'entries'
   this._footer = document.createElement('footer')
   this._footer.id = 'footer'
-  this._footer.innerHTML = `<p>The <strong>Hallway</strong> is a decentralized forum, to join the conversation, add a <a href="https://github.com/XXIIVV/webring#joining-the-hallway">feed:</a> field to your entry in the <a href="https://github.com/XXIIVV/Webring/">webring</a>.</p>`
+  this.readme = `<p>The <strong>Hallway</strong> is a decentralized forum, to join the conversation, add a <a href="https://github.com/XXIIVV/webring#joining-the-hallway">feed:</a> field to your entry in the <a href="https://github.com/XXIIVV/Webring/">webring</a>.</p>`
+  this.nav = `<p class='buttons'><a href='https://github.com/XXIIVV/webring'>Information</a> | <a href="index.html">The Portal</a>  | <a href="wiki.html">The Wiki</a> | <a id="opml">OPML</a></p>`
+  this._footer.innerHTML = `${this.readme}${this.nav}`
 
   this.install = function (host) {
     this._el.appendChild(this._main)

--- a/scripts/opml.js
+++ b/scripts/opml.js
@@ -1,11 +1,13 @@
-let outlines = sites.filter((site) => !!site.rss).map((site) => {
+const outlines = sites.filter(site => site.rss).map(site => {
   return `<outline type="rss" xmlUrl="${site.rss}" title="${site.title}"/>`
 })
 
-let template = `<?xml version="1.0" encoding="UTF-8"?><opml version="1.1"><head></head><body>${outlines.join('')}</body></opml>`
+const template = `<?xml version="1.0" encoding="UTF-8"?><opml version="1.1"><head></head><body>${outlines.join('')}</body></opml>`
 
 window.onload = function () {
-  let a = document.getElementById('opml')
-  a.setAttribute('href', 'data:text/plain;charset=utf-8,' + window.encodeURIComponent(template))
-  a.setAttribute('download', 'webring.opml')
+  const a = document.getElementById('opml')
+  if (a) {
+    a.setAttribute('href', 'data:text/plain;charset=utf-8,' + window.encodeURIComponent(template))
+    a.setAttribute('download', 'webring.opml')
+  }
 }

--- a/wiki.html
+++ b/wiki.html
@@ -19,6 +19,7 @@
     </main>
     <footer id="footer">
       <p>The <strong>Wiki</strong> is a decentralized encyclopedia, to join the conversation, add a <a href="https://github.com/XXIIVV/webring#joining-the-wiki">wiki:</a> field to your entry in the <a href="https://github.com/XXIIVV/Webring/">webring</a>.</p>
+      <p class='buttons'><a href='https://github.com/XXIIVV/webring'>Information</a> | <a href="hallway.html">The Hallway</a>  | <a href="index.html">The Portal</a> | <a id="opml">OPML</a></p>
       <div id="progress"></div>
     </footer>
   </div>


### PR DESCRIPTION
closes #265 
closes #246 

This adds in a minimal nav in the wiki and hallway to mimic the way it is in the portal. I also added in logic to fix the opml console error when you are on random.

I also changed the styling a bit to better accommodate mobile, but tbh, the mobile view just really needs an overhaul. I'll create an issue and show some screenshots of what I mean.

New Wiki nav:
![image](https://user-images.githubusercontent.com/13974112/62833620-2ec47080-bc42-11e9-9ee6-bf45bb93ece5.png)

New Hallway nav:
 
![image](https://user-images.githubusercontent.com/13974112/62833623-3dab2300-bc42-11e9-8c6c-df8f0fb87334.png)
