### PR TITLE
Add script to fix OPML link on Wiki

### DIFF
--- a/scripts/opml.js
+++ b/scripts/opml.js
@@ -4,10 +4,10 @@ const outlines = sites.filter(site => site.rss).map(site => {
 
 const template = `<?xml version="1.0" encoding="UTF-8"?><opml version="1.1"><head></head><body>${outlines.join('')}</body></opml>`
 
-window.onload = function () {
+window.addEventListener('DOMContentLoaded', () => {
   const a = document.getElementById('opml')
   if (a) {
     a.setAttribute('href', 'data:text/plain;charset=utf-8,' + window.encodeURIComponent(template))
     a.setAttribute('download', 'webring.opml')
   }
-}
+})

--- a/wiki.html
+++ b/wiki.html
@@ -9,6 +9,7 @@
   <script src="scripts/wiki.js"></script>
   <script src="scripts/sites.js"></script>
   <script src="scripts/indental.js"></script>
+  <script src="scripts/opml.js"></script>
   <title>Wiki</title>
 </head>
 <body>


### PR DESCRIPTION
Also replaced the `window.onload` assignment with a `DOMContentLoaded` event listener.