### PR TITLE
add in cleanEntry function

### DIFF
--- a/scripts/wiki.js
+++ b/scripts/wiki.js
@@ -9,7 +9,17 @@ const Wiki = sites => {
   const authors = new Set()
   const terms = new Set()
 
-  const storeEntry = (author, url, category, term, entry) => {
+  const cleanEntry = entry => {
+    const temp = document.createElement('div')
+    temp.textContent = entry
+    return temp.innerHTML
+  }
+
+  const storeEntry = (author, url, category, term, unCleanEntry) => {
+    const entry = Array.isArray(unCleanEntry)
+      ? unCleanEntry.map(x => cleanEntry(x))
+      : cleanEntry(unCleanEntry)
+
     if (!(category in entries)) {
       entries[category] = {}
       entries[category][term] = [{ entry, authors: [{ author, url }] }]


### PR DESCRIPTION
This is maybe a cheeky way to do this, but it will solve our problem well while also preventing potential xss threats from someone that would want to try something along that line.

This will cause whatever the entry is to be forced to text and attached to a temp element. Note this element isn't attached to the dom yet, so there is no risk there. We then return innerHtml from that temp element which will be a cleaned string.

It will turn this...

![image](https://user-images.githubusercontent.com/13974112/62950408-40477d00-bde8-11e9-9b37-6e2df54489b7.png)

..into this...

![image](https://user-images.githubusercontent.com/13974112/62950438-535a4d00-bde8-11e9-99c0-d305c1ad8870.png)

It also close #271 and protects from comments and scripts.