### PR TITLE
Add missing metadata keys for chigby.org

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -24,7 +24,7 @@ const sites = [
   { url: 'https://shaneckel.com' },
   { url: 'https://cblgh.org', title: 'cblgh.org', author: 'cblgh', contact: 'cabal://cblgh.org', feed: 'https://cblgh.org/twtxt.txt' },
   { url: 'https://ellugar.co', title: 'ellugar', type: 'wiki', author: 'afk', contact: 'afk@ellugar.co', rss: 'http://feeds.ellugar.co/ellugar-logs' },
-  { url: 'http://chigby.org' },
+  { url: 'http://chigby.org', title: 'chigby.org', type: 'portfolio', contact: 'me@chigby.org', author: 'Cameron Higby-Naquin' },
   { url: 'https://longest.voyage' },
   { url: 'https://palomakop.tv' },
   { url: 'https://v-os.ca' },


### PR DESCRIPTION
Apparently I missed when these options were added, so just filing in the missing info.