### PR TITLE
make sites.js human-readable

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -4,603 +4,603 @@
 // protocol://url.domain.ext
 
 const sites = [
-{
-  url: 'https://wiki.xxiivv.com',
-  title: 'xxiivv',
-  type: 'wiki',
-  author: 'neauoire',
-  contact: 'aliceffekt@gmail.com',
-  rss: 'https://wiki.xxiivv.com/links/rss.xml',
-  feed: 'https://wiki.xxiivv.com/twtxt.txt',
-  wiki: 'https://wiki.xxiivv.com/scripts/database/glossary.ndtl',
-},
-
-{
-  url: 'http://estevancarlos.com'
-},
-
-{
-  url: 'https://electro.pizza',
-  title: 'electro pizza',
-  type: 'blog',
-  author: 'rho',
-  rss: 'https://electro.pizza/feed.xml',
-  feed: 'https://electro.pizza/twtxt.txt',
-},
-
-{
-  url: 'https://avanier.now.sh',
-  title: 'Arachne',
-  type: 'wiki',
-  author: 'joshavanier',
-  contact: 'joshavanier@protonmail.com',
-  feed: 'https://avanier.now.sh/tw.txt',
-},
-
-{
-  url: 'http://kaemura.com',
-  title: 'kaemura.com',
-  type: 'blog',
-  author: 'kaemura',
-  contact: 'chimera1190@gmail.com',
-  feed: 'https://kaemura.com/twttxt.txt',
-},
-
-{
-  url: 'https://liamcooke.com',
-  title: 'liamcooke.com',
-  author: 'slisne',
-  contact: '@slisne@merveilles.town',
-  rss: 'https://liamcooke.com/feed.xml',
-  wiki: 'https://liamcooke.com/merveilles/wiki.ndtl',
-  feed: 'https://liamcooke.com/merveilles/tw.txt',
-},
-
-{
-  url: 'https://electricgecko.de',
-  title: 'electricgecko',
-  type: 'blog',
-  author: 'electricgecko',
-  contact: 'desk@electricgecko.de',
-  rss: 'https://electricgecko.de/feed',
-},
-
-{
-  url: 'https://wichniow.ski'
-},
-
-{
-  url: 'https://hraew.autophagy.io'
-},
-
-{
-  url: 'http://evenunto.net'
-},
-
-{
-  url: 'https://anxl.faith'
-},
-
-{
-  url: 'https://xvw.github.io',
-  title: 'xvw.github.io',
-  type: 'blog',
-  author: 'xvw',
-  contact: 'xaviervdw@gmail.com',
-  rss: 'https://xvw.github.io/atom.xml',
-},
-
-{
-  url: 'https://heracl.es'
-},
-
-{
-  url: 'http://luminghao.com'
-},
-
-{
-  url: 'https://turelio.github.io'
-},
-
-{
-  url: 'https://log.lectronice.com',
-  title: 'lectrolog.',
-  type: 'blog',
-  author: 'lectronice',
-  contact: 'i.love.spam@lectronice.com',
-  feed: 'https://lectronice.com/hallway/twtxt.txt',
-},
-
-{
-  url: 'https://craze.co.uk'
-},
-
-{
-  url: 'https://shaneckel.com'
-},
-
-{
-  url: 'https://cblgh.org',
-  title: 'cblgh.org',
-  author: 'cblgh',
-  contact: 'cabal://cblgh.org',
-  feed: 'https://cblgh.org/twtxt.txt',
-},
-
-{
-  url: 'https://ellugar.co',
-  title: 'ellugar',
-  type: 'wiki',
-  author: 'afk',
-  contact: 'afk@ellugar.co',
-  rss: 'http://feeds.ellugar.co/ellugar-logs',
-},
-
-{
-  url: 'http://chigby.org',
-  title: 'chigby.org',
-  type: 'portfolio',
-  contact: 'me@chigby.org',
-  author: 'Cameron Higby-Naquin',
-},
-
-{
-  url: 'https://longest.voyage'
-},
-
-{
-  url: 'https://palomakop.tv'
-},
-
-{
-  url: 'https://v-os.ca'
-},
-
-{
-  url: 'https://jmandel.xyz'
-},
-
-{
-  url: 'https://systems.ws'
-},
-
-{
-  url: 'https://2d4.dev',
-  title: '2d4.dev',
-  author: 'jda0',
-  contact: 'hi@2d4.dev',
-  feed: 'https://2d4.dev/tw.txt',
-  wiki: 'https://2d4.dev/wiki.ndtl',
-},
-
-{
-  url: 'https://nathanwentworth.co'
-},
-
-{
-  url: 'https://uonai.space'
-},
-
-{
-  url: 'http://controls.ee'
-},
-
-{
-  url: 'https://wasin.io'
-},
-
-{
-  url: 'https://inns.studio'
-},
-
-{
-  url: 'http://kokorobot.ca'
-},
-
-{
-  url: 'https://ameyama.com',
-  title: 'ameyama',
-  type: 'blog',
-  author: 'jrc03c',
-  contact: 'josh@ameyama.com',
-  rss: 'https://ameyama.com/blog/rss.xml',
-  wiki: 'https://ameyama.com/data/wiki.ndtl',
-},
-
-{
-  url: 'https://wake.st',
-  title: 'wake.st',
-  author: 'wakest',
-  contact: '@liaizon@wake.st',
-  feed: 'https://wake.st/twtxt.txt',
-},
-
-{
-  url: 'https://xarene.la'
-},
-
-{
-  url: 'https://alex.zyzhang.me'
-},
-
-{
-  url: 'http://bildwissenschaft.vortok.info'
-},
-
-{
-  url: 'https://jakofranko.github.com'
-},
-
-{
-  url: 'https://aeriform.io'
-},
-
-{
-  url: 'http://blog.lucasdidthis.com'
-},
-
-{
-  url: 'http://npisanti.com',
-  title: 'npisanti.com',
-  author: 'npisanti',
-  contact: 'nicola@npisanti.com',
-  rss: 'http://npisanti.com/journal/rss.xml',
-},
-
-{
-  url: 'https://underscorediscovery.ca'
-},
-
-{
-  url: 'https://drisc.io',
-  title: 'drisc.io',
-  type: 'wiki',
-  author: 'drisc',
-  contact: 'cory@drisc.io',
-  feed: 'https://drisc.io/hallway/twtxt.txt',
-},
-
-{
-  url: 'https://neufv.systems',
-  author: 'neufv',
-},
-
-{
-  url: 'https://ricky.codes'
-},
-
-{
-  url: 'https://maxdeviant.com'
-},
-
-{
-  url: 'https://tynandebold.com'
-},
-
-{
-  url: 'http://gytis.co'
-},
-
-{
-  url: 'https://nomand.co'
-},
-
-{
-  url: 'http://memoriata.com'
-},
-
-{
-  url: 'https://mmm.s-ol.nu'
-},
-
-{
-  url: 'https://chad.is'
-},
-
-{
-  url: 'https://smidgeo.com/bots'
-},
-
-{
-  url: 'https://iko.soy'
-},
-
-{
-  url: 'http://atelieroilandsugar.com'
-},
-
-{
-  url: 'https://magoz.is'
-},
-
-{
-  url: 'https://szymonkaliski.com',
-  author: 'Szymon Kaliski',
-  type: 'hybrid',
-  rss: 'https://szymonkaliski.com/feed.xml',
-},
-
-{
-  url: 'https://phse.net',
-  title: 'phse.net',
-  type: 'blog',
-  author: 'setphen',
-  rss: 'https://phse.net/post/index.xml',
-  feed: 'https://phse.net/twtxt/merv.txt',
-},
-
-{
-  url: 'https://rosano.ca'
-},
-
-{
-  url: 'https://soyboysky.github.io'
-},
-
-{
-  url: 'https://gndclouds.cc'
-},
-
-{
-  url: 'https://xuv.be'
-},
-
-{
-  url: 'https://dsdshcym.github.io'
-},
-
-{
-  url: 'https://wiki.chronica.xyz',
-  title: 'chronica',
-  type: 'wiki',
-  author: 'ckipp',
-  contact: 'ckipp@pm.me',
-  feed: 'https://chronica.xyz/hallway.txt',
-  wiki: 'https://chronica.xyz/glossary.ndtl',
-},
-
-{
-  url: 'https://boffosocko.com'
-},
-
-{
-  url: 'https://hex22.org',
-  title: 'hex22',
-  author: 'kodedninja',
-  contact: 'karamanhunor@pm.me',
-  feed: 'https://t.seed.hex22.org/twtxt.txt',
-},
-
-{
-  url: 'https://patrikarvidsson.com'
-},
-
-{
-  url: 'https://sophieleetmaa.com'
-},
-
-{
-  url: 'https://xinniw.github.io'
-},
-
-{
-  url: 'https://mboxed.github.io/sodatsu',
-  title: 'sodatsu',
-  type: 'wiki',
-  author: 'm',
-  contact: 'mboxxed@gmail.com',
-  feed: 'https://mboxed.github.io/sodatsu/tw.txt',
-},
-
-{
-  url: 'https://letters.vexingworkshop.com'
-},
-
-{
-  url: 'https://tom.org.nz',
-  title: 'Tom Hackshaw',
-  type: 'portfolio',
-  author: 'tomupom',
-  contact: 'tom@tomhackshaw.com',
-  wiki: 'https://a.tom.org.nz/glossary.ndtl',
-},
-
-{
-  url: 'https://teknari.com'
-},
-
-{
-  url: 'https://colectivo-de-livecoders.gitlab.io',
-  title: 'Colectivo de Livecoders',
-  type: 'blog',
-  author: 'clic',
-  contact: 'https://t.me/clic_laplata',
-},
-
-{
-  url: 'https://www.madewithtea.com',
-  title: 'madewithtea.com',
-  type: 'blog',
-},
-
-{
-  url: 'https://amorris.ca',
-  title: 'amorris',
-  author: 'amorris',
-  type: 'blog',
-  feed: 'https://feed.amorris.ca/hallway.txt',
-  wiki: 'https://wiki.amorris.ca/glossary.ndtl',
-},
-
-{
-  url: 'http://www.miha-co.ca',
-  title: 'miha-co',
-  type: 'portfolio',
-},
-
-{
-  url: 'https://buzzert.net',
-  title: 'buzzert.net',
-  author: 'buzzert',
-  type: 'blog',
-},
-
-{
-  url: 'https://notes.stuartpb.com/',
-  title: 'notes.stuartpb.com',
-  type: 'wiki',
-  author: 'stuartpb',
-  contact: 's@stuartpb.com',
-  feed: 'https://twtxt.stuartpb.com/xxiivv.txt',
-},
-
-{
-  url: 'https://xxiii.co',
-  title: 'xxiii',
-  type: 'portfolio',
-  author: 'serocell',
-  contact: 'psignal@s900.net',
-  rss: 'https://serocell.com/feeds/serocell.xml',
-  feed: 'https://xxiii.co/twtxt.txt',
-},
-
-{
-  url: 'https://kor.nz',
-  title: 'kor',
-  type: 'wiki',
-  author: 'kormyen',
-  contact: 'h@kor.nz',
-  feed: 'https://kor.nz/twtxt.txt',
-  wiki: 'https://kor.nz/db/glossary.ndtl',
-},
-
-{
-  url: 'https://lublin.se',
-  author: 'quite',
-  contact: 'quite@hack.org',
-  feed: 'https://lublin.se/twtxt.txt',
-},
-
-{
-  url: 'https://zanneth.com',
-  title: 'zanneth.com',
-  author: 'zanneth',
-  type: 'blog',
-  contact: 'root@zanneth.com',
-},
-
-{
-  url: 'https://eli.li',
-  title: 'eli.li',
-  author: 'eli_oat',
-  type: 'blog',
-  contact: 'hi@eli.li',
-  rss: 'https://eli.li/feed.rss',
-  feed: 'https://txt.eli.li/twtxt/twtxt.txt',
-},
-
-{
-  url: 'https://gueorgui.net',
-  title: 'Gueorgui Tcherednitchenko',
-  author: 'gueorgui',
-  type: 'portfolio',
-  contact: 'hello@gueorgui.net',
-},
-
-{
-  url: 'https://www.gkbrk.com',
-  title: 'Leo',
-  author: 'Leo',
-  type: 'blog',
-  contact: 'webring@gkbrk.com',
-  rss: 'https://www.gkbrk.com/feed.xml',
-  feed: 'https://www.gkbrk.com/twtxt.txt',
-},
-
-{
-  url: 'https://www.tatecarson.com',
-  title: 'Tate Carson',
-  type: 'portfolio',
-  author: 'Tate Carson',
-  contact: 'tatecarson@gmail.com',
-},
-
-{
-  url: 'https://azlen.me',
-  title: 'azlen.me',
-  author: 'azlen',
-  type: 'wiki',
-  contact: 'webring@azlen.me',
-  feed: 'https://azlen.me/twtxt.txt',
-  wiki: 'https://azlen.me/glossary.ndtl',
-},
-
-{
-  url: 'https://opinionatedguide.github.io/',
-  title: 'OpGuides',
-  author: 'vega',
-  contact: 'vegac@protonmail.com',
-  feed: 'https://opinionatedguide.github.io/twtxt.txt',
-},
-
-{
-  url: 'https://chrismaughan.com/',
-  title: 'CMaughan',
-  author: 'cmaughan',
-  contact: 'mornymorny@gmail.com',
-  feed: 'https://chrismaughan.com/twtxt.txt',
-},
-
-{
-  url: 'https://oddworlds.org/',
-  title: 'oddworlds soliloquy',
-  type: 'blog',
-  author: 'RaelZero',
-  contact: 'gaz.gong@gmail.com',
-},
-
-{
-  url: 'https://fundor333.com/',
-  title: 'Fundor333',
-  type: 'blog',
-  author: 'Fundor 333',
-  contact: 'blog@fundor333.com',
-  feed: 'https://fundor333.com/twtxt.txt',
-},
-
-{
-  url: 'https://cass.si/',
-  contact: 'm@cass.si',
-},
-
-{
-  url: 'https://dotcomboom.somnolescent.net/',
-  title: 'dotcomboom.somnolescent.net',
-  author: 'dcb',
-  contact: 'dotcomboom@somnolescent.net',
-  feed: 'https://dotcomboom.somnolescent.net/twtxt.txt',
-},
-
-{
-  url: 'https://cadmican.neocities.org/',
-  title: 'cadmican',
-  contact: 'arachi@airmail.cc',
-  author: 'Nihiltarier',
-},
-
-{
-  url: 'https://jskjott.com',
-  title: 'jskjott',
-  contact: 'jonathan@jskjott.com',
-  author: 'Jonathan Skjøtt',
-},
-
-{
-  url: 'https://sixey.es/',
-  title: 'sixey.es',
-  contact: 'elmusho@gmail.com',
-  author: 'sixeyes',
-  type: 'portfolio',
-},
+  {
+    url: 'https://wiki.xxiivv.com',
+    title: 'xxiivv',
+    type: 'wiki',
+    author: 'neauoire',
+    contact: 'aliceffekt@gmail.com',
+    rss: 'https://wiki.xxiivv.com/links/rss.xml',
+    feed: 'https://wiki.xxiivv.com/twtxt.txt',
+    wiki: 'https://wiki.xxiivv.com/scripts/database/glossary.ndtl'
+  },
+
+  {
+    url: 'http://estevancarlos.com'
+  },
+
+  {
+    url: 'https://electro.pizza',
+    title: 'electro pizza',
+    type: 'blog',
+    author: 'rho',
+    rss: 'https://electro.pizza/feed.xml',
+    feed: 'https://electro.pizza/twtxt.txt'
+  },
+
+  {
+    url: 'https://avanier.now.sh',
+    title: 'Arachne',
+    type: 'wiki',
+    author: 'joshavanier',
+    contact: 'joshavanier@protonmail.com',
+    feed: 'https://avanier.now.sh/tw.txt'
+  },
+
+  {
+    url: 'http://kaemura.com',
+    title: 'kaemura.com',
+    type: 'blog',
+    author: 'kaemura',
+    contact: 'chimera1190@gmail.com',
+    feed: 'https://kaemura.com/twttxt.txt'
+  },
+
+  {
+    url: 'https://liamcooke.com',
+    title: 'liamcooke.com',
+    author: 'slisne',
+    contact: '@slisne@merveilles.town',
+    rss: 'https://liamcooke.com/feed.xml',
+    wiki: 'https://liamcooke.com/merveilles/wiki.ndtl',
+    feed: 'https://liamcooke.com/merveilles/tw.txt'
+  },
+
+  {
+    url: 'https://electricgecko.de',
+    title: 'electricgecko',
+    type: 'blog',
+    author: 'electricgecko',
+    contact: 'desk@electricgecko.de',
+    rss: 'https://electricgecko.de/feed'
+  },
+
+  {
+    url: 'https://wichniow.ski'
+  },
+
+  {
+    url: 'https://hraew.autophagy.io'
+  },
+
+  {
+    url: 'http://evenunto.net'
+  },
+
+  {
+    url: 'https://anxl.faith'
+  },
+
+  {
+    url: 'https://xvw.github.io',
+    title: 'xvw.github.io',
+    type: 'blog',
+    author: 'xvw',
+    contact: 'xaviervdw@gmail.com',
+    rss: 'https://xvw.github.io/atom.xml'
+  },
+
+  {
+    url: 'https://heracl.es'
+  },
+
+  {
+    url: 'http://luminghao.com'
+  },
+
+  {
+    url: 'https://turelio.github.io'
+  },
+
+  {
+    url: 'https://log.lectronice.com',
+    title: 'lectrolog.',
+    type: 'blog',
+    author: 'lectronice',
+    contact: 'i.love.spam@lectronice.com',
+    feed: 'https://lectronice.com/hallway/twtxt.txt'
+  },
+
+  {
+    url: 'https://craze.co.uk'
+  },
+
+  {
+    url: 'https://shaneckel.com'
+  },
+
+  {
+    url: 'https://cblgh.org',
+    title: 'cblgh.org',
+    author: 'cblgh',
+    contact: 'cabal://cblgh.org',
+    feed: 'https://cblgh.org/twtxt.txt'
+  },
+
+  {
+    url: 'https://ellugar.co',
+    title: 'ellugar',
+    type: 'wiki',
+    author: 'afk',
+    contact: 'afk@ellugar.co',
+    rss: 'http://feeds.ellugar.co/ellugar-logs'
+  },
+
+  {
+    url: 'http://chigby.org',
+    title: 'chigby.org',
+    type: 'portfolio',
+    contact: 'me@chigby.org',
+    author: 'Cameron Higby-Naquin'
+  },
+
+  {
+    url: 'https://longest.voyage'
+  },
+
+  {
+    url: 'https://palomakop.tv'
+  },
+
+  {
+    url: 'https://v-os.ca'
+  },
+
+  {
+    url: 'https://jmandel.xyz'
+  },
+
+  {
+    url: 'https://systems.ws'
+  },
+
+  {
+    url: 'https://2d4.dev',
+    title: '2d4.dev',
+    author: 'jda0',
+    contact: 'hi@2d4.dev',
+    feed: 'https://2d4.dev/tw.txt',
+    wiki: 'https://2d4.dev/wiki.ndtl'
+  },
+
+  {
+    url: 'https://nathanwentworth.co'
+  },
+
+  {
+    url: 'https://uonai.space'
+  },
+
+  {
+    url: 'http://controls.ee'
+  },
+
+  {
+    url: 'https://wasin.io'
+  },
+
+  {
+    url: 'https://inns.studio'
+  },
+
+  {
+    url: 'http://kokorobot.ca'
+  },
+
+  {
+    url: 'https://ameyama.com',
+    title: 'ameyama',
+    type: 'blog',
+    author: 'jrc03c',
+    contact: 'josh@ameyama.com',
+    rss: 'https://ameyama.com/blog/rss.xml',
+    wiki: 'https://ameyama.com/data/wiki.ndtl'
+  },
+
+  {
+    url: 'https://wake.st',
+    title: 'wake.st',
+    author: 'wakest',
+    contact: '@liaizon@wake.st',
+    feed: 'https://wake.st/twtxt.txt'
+  },
+
+  {
+    url: 'https://xarene.la'
+  },
+
+  {
+    url: 'https://alex.zyzhang.me'
+  },
+
+  {
+    url: 'http://bildwissenschaft.vortok.info'
+  },
+
+  {
+    url: 'https://jakofranko.github.com'
+  },
+
+  {
+    url: 'https://aeriform.io'
+  },
+
+  {
+    url: 'http://blog.lucasdidthis.com'
+  },
+
+  {
+    url: 'http://npisanti.com',
+    title: 'npisanti.com',
+    author: 'npisanti',
+    contact: 'nicola@npisanti.com',
+    rss: 'http://npisanti.com/journal/rss.xml'
+  },
+
+  {
+    url: 'https://underscorediscovery.ca'
+  },
+
+  {
+    url: 'https://drisc.io',
+    title: 'drisc.io',
+    type: 'wiki',
+    author: 'drisc',
+    contact: 'cory@drisc.io',
+    feed: 'https://drisc.io/hallway/twtxt.txt'
+  },
+
+  {
+    url: 'https://neufv.systems',
+    author: 'neufv'
+  },
+
+  {
+    url: 'https://ricky.codes'
+  },
+
+  {
+    url: 'https://maxdeviant.com'
+  },
+
+  {
+    url: 'https://tynandebold.com'
+  },
+
+  {
+    url: 'http://gytis.co'
+  },
+
+  {
+    url: 'https://nomand.co'
+  },
+
+  {
+    url: 'http://memoriata.com'
+  },
+
+  {
+    url: 'https://mmm.s-ol.nu'
+  },
+
+  {
+    url: 'https://chad.is'
+  },
+
+  {
+    url: 'https://smidgeo.com/bots'
+  },
+
+  {
+    url: 'https://iko.soy'
+  },
+
+  {
+    url: 'http://atelieroilandsugar.com'
+  },
+
+  {
+    url: 'https://magoz.is'
+  },
+
+  {
+    url: 'https://szymonkaliski.com',
+    author: 'Szymon Kaliski',
+    type: 'hybrid',
+    rss: 'https://szymonkaliski.com/feed.xml'
+  },
+
+  {
+    url: 'https://phse.net',
+    title: 'phse.net',
+    type: 'blog',
+    author: 'setphen',
+    rss: 'https://phse.net/post/index.xml',
+    feed: 'https://phse.net/twtxt/merv.txt'
+  },
+
+  {
+    url: 'https://rosano.ca'
+  },
+
+  {
+    url: 'https://soyboysky.github.io'
+  },
+
+  {
+    url: 'https://gndclouds.cc'
+  },
+
+  {
+    url: 'https://xuv.be'
+  },
+
+  {
+    url: 'https://dsdshcym.github.io'
+  },
+
+  {
+    url: 'https://wiki.chronica.xyz',
+    title: 'chronica',
+    type: 'wiki',
+    author: 'ckipp',
+    contact: 'ckipp@pm.me',
+    feed: 'https://chronica.xyz/hallway.txt',
+    wiki: 'https://chronica.xyz/glossary.ndtl'
+  },
+
+  {
+    url: 'https://boffosocko.com'
+  },
+
+  {
+    url: 'https://hex22.org',
+    title: 'hex22',
+    author: 'kodedninja',
+    contact: 'karamanhunor@pm.me',
+    feed: 'https://t.seed.hex22.org/twtxt.txt'
+  },
+
+  {
+    url: 'https://patrikarvidsson.com'
+  },
+
+  {
+    url: 'https://sophieleetmaa.com'
+  },
+
+  {
+    url: 'https://xinniw.github.io'
+  },
+
+  {
+    url: 'https://mboxed.github.io/sodatsu',
+    title: 'sodatsu',
+    type: 'wiki',
+    author: 'm',
+    contact: 'mboxxed@gmail.com',
+    feed: 'https://mboxed.github.io/sodatsu/tw.txt'
+  },
+
+  {
+    url: 'https://letters.vexingworkshop.com'
+  },
+
+  {
+    url: 'https://tom.org.nz',
+    title: 'Tom Hackshaw',
+    type: 'portfolio',
+    author: 'tomupom',
+    contact: 'tom@tomhackshaw.com',
+    wiki: 'https://a.tom.org.nz/glossary.ndtl'
+  },
+
+  {
+    url: 'https://teknari.com'
+  },
+
+  {
+    url: 'https://colectivo-de-livecoders.gitlab.io',
+    title: 'Colectivo de Livecoders',
+    type: 'blog',
+    author: 'clic',
+    contact: 'https://t.me/clic_laplata'
+  },
+
+  {
+    url: 'https://www.madewithtea.com',
+    title: 'madewithtea.com',
+    type: 'blog'
+  },
+
+  {
+    url: 'https://amorris.ca',
+    title: 'amorris',
+    author: 'amorris',
+    type: 'blog',
+    feed: 'https://feed.amorris.ca/hallway.txt',
+    wiki: 'https://wiki.amorris.ca/glossary.ndtl'
+  },
+
+  {
+    url: 'http://www.miha-co.ca',
+    title: 'miha-co',
+    type: 'portfolio'
+  },
+
+  {
+    url: 'https://buzzert.net',
+    title: 'buzzert.net',
+    author: 'buzzert',
+    type: 'blog'
+  },
+
+  {
+    url: 'https://notes.stuartpb.com/',
+    title: 'notes.stuartpb.com',
+    type: 'wiki',
+    author: 'stuartpb',
+    contact: 's@stuartpb.com',
+    feed: 'https://twtxt.stuartpb.com/xxiivv.txt'
+  },
+
+  {
+    url: 'https://xxiii.co',
+    title: 'xxiii',
+    type: 'portfolio',
+    author: 'serocell',
+    contact: 'psignal@s900.net',
+    rss: 'https://serocell.com/feeds/serocell.xml',
+    feed: 'https://xxiii.co/twtxt.txt'
+  },
+
+  {
+    url: 'https://kor.nz',
+    title: 'kor',
+    type: 'wiki',
+    author: 'kormyen',
+    contact: 'h@kor.nz',
+    feed: 'https://kor.nz/twtxt.txt',
+    wiki: 'https://kor.nz/db/glossary.ndtl'
+  },
+
+  {
+    url: 'https://lublin.se',
+    author: 'quite',
+    contact: 'quite@hack.org',
+    feed: 'https://lublin.se/twtxt.txt'
+  },
+
+  {
+    url: 'https://zanneth.com',
+    title: 'zanneth.com',
+    author: 'zanneth',
+    type: 'blog',
+    contact: 'root@zanneth.com'
+  },
+
+  {
+    url: 'https://eli.li',
+    title: 'eli.li',
+    author: 'eli_oat',
+    type: 'blog',
+    contact: 'hi@eli.li',
+    rss: 'https://eli.li/feed.rss',
+    feed: 'https://txt.eli.li/twtxt/twtxt.txt'
+  },
+
+  {
+    url: 'https://gueorgui.net',
+    title: 'Gueorgui Tcherednitchenko',
+    author: 'gueorgui',
+    type: 'portfolio',
+    contact: 'hello@gueorgui.net'
+  },
+
+  {
+    url: 'https://www.gkbrk.com',
+    title: 'Leo',
+    author: 'Leo',
+    type: 'blog',
+    contact: 'webring@gkbrk.com',
+    rss: 'https://www.gkbrk.com/feed.xml',
+    feed: 'https://www.gkbrk.com/twtxt.txt'
+  },
+
+  {
+    url: 'https://www.tatecarson.com',
+    title: 'Tate Carson',
+    type: 'portfolio',
+    author: 'Tate Carson',
+    contact: 'tatecarson@gmail.com'
+  },
+
+  {
+    url: 'https://azlen.me',
+    title: 'azlen.me',
+    author: 'azlen',
+    type: 'wiki',
+    contact: 'webring@azlen.me',
+    feed: 'https://azlen.me/twtxt.txt',
+    wiki: 'https://azlen.me/glossary.ndtl'
+  },
+
+  {
+    url: 'https://opinionatedguide.github.io/',
+    title: 'OpGuides',
+    author: 'vega',
+    contact: 'vegac@protonmail.com',
+    feed: 'https://opinionatedguide.github.io/twtxt.txt'
+  },
+
+  {
+    url: 'https://chrismaughan.com/',
+    title: 'CMaughan',
+    author: 'cmaughan',
+    contact: 'mornymorny@gmail.com',
+    feed: 'https://chrismaughan.com/twtxt.txt'
+  },
+
+  {
+    url: 'https://oddworlds.org/',
+    title: 'oddworlds soliloquy',
+    type: 'blog',
+    author: 'RaelZero',
+    contact: 'gaz.gong@gmail.com'
+  },
+
+  {
+    url: 'https://fundor333.com/',
+    title: 'Fundor333',
+    type: 'blog',
+    author: 'Fundor 333',
+    contact: 'blog@fundor333.com',
+    feed: 'https://fundor333.com/twtxt.txt'
+  },
+
+  {
+    url: 'https://cass.si/',
+    contact: 'm@cass.si'
+  },
+
+  {
+    url: 'https://dotcomboom.somnolescent.net/',
+    title: 'dotcomboom.somnolescent.net',
+    author: 'dcb',
+    contact: 'dotcomboom@somnolescent.net',
+    feed: 'https://dotcomboom.somnolescent.net/twtxt.txt'
+  },
+
+  {
+    url: 'https://cadmican.neocities.org/',
+    title: 'cadmican',
+    contact: 'arachi@airmail.cc',
+    author: 'Nihiltarier'
+  },
+
+  {
+    url: 'https://jskjott.com',
+    title: 'jskjott',
+    contact: 'jonathan@jskjott.com',
+    author: 'Jonathan Skjøtt'
+  },
+
+  {
+    url: 'https://sixey.es/',
+    title: 'sixey.es',
+    contact: 'elmusho@gmail.com',
+    author: 'sixeyes',
+    type: 'portfolio'
+  }
 
 ]

--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -3,103 +3,455 @@
 // Don't forget the comma! No trailing slashes
 // protocol://url.domain.ext
 
-const sites = [
-  { url: 'https://wiki.xxiivv.com', title: 'xxiivv', type: 'wiki', author: 'neauoire', contact: 'aliceffekt@gmail.com', rss: 'https://wiki.xxiivv.com/links/rss.xml', feed: 'https://wiki.xxiivv.com/twtxt.txt', wiki: 'https://wiki.xxiivv.com/scripts/database/glossary.ndtl' },
-  { url: 'http://estevancarlos.com' },
-  { url: 'https://electro.pizza', title: 'electro pizza', type: 'blog', author: 'rho', rss: 'https://electro.pizza/feed.xml', feed: 'https://electro.pizza/twtxt.txt' },
-  { url: 'https://avanier.now.sh', title: 'Arachne', type: 'wiki', author: 'joshavanier', contact: 'joshavanier@protonmail.com', feed: 'https://avanier.now.sh/tw.txt' },
-  { url: 'http://kaemura.com', title: 'kaemura.com', type: 'blog', author: 'kaemura', contact: 'chimera1190@gmail.com', feed: 'https://kaemura.com/twttxt.txt' },
-  { url: 'https://liamcooke.com', title: 'liamcooke.com', author: 'slisne', contact: '@slisne@merveilles.town', rss: 'https://liamcooke.com/feed.xml', wiki: 'https://liamcooke.com/merveilles/wiki.ndtl', feed: 'https://liamcooke.com/merveilles/tw.txt' },
-  { url: 'https://electricgecko.de', title: 'electricgecko', type: 'blog', author: 'electricgecko', contact: 'desk@electricgecko.de', rss: 'https://electricgecko.de/feed' },
-  { url: 'https://wichniow.ski' },
-  { url: 'https://hraew.autophagy.io' },
-  { url: 'http://evenunto.net' },
-  { url: 'https://anxl.faith' },
-  { url: 'https://xvw.github.io', title: 'xvw.github.io', type: 'blog', author: 'xvw', contact: 'xaviervdw@gmail.com', rss: 'https://xvw.github.io/atom.xml' },
-  { url: 'https://heracl.es' },
-  { url: 'http://luminghao.com' },
-  { url: 'https://turelio.github.io' },
-  { url: 'https://log.lectronice.com', title: 'lectrolog.', type: 'blog', author: 'lectronice', contact: 'i.love.spam@lectronice.com', feed: 'https://lectronice.com/hallway/twtxt.txt' },
-  { url: 'https://craze.co.uk' },
-  { url: 'https://shaneckel.com' },
-  { url: 'https://cblgh.org', title: 'cblgh.org', author: 'cblgh', contact: 'cabal://cblgh.org', feed: 'https://cblgh.org/twtxt.txt' },
-  { url: 'https://ellugar.co', title: 'ellugar', type: 'wiki', author: 'afk', contact: 'afk@ellugar.co', rss: 'http://feeds.ellugar.co/ellugar-logs' },
-  { url: 'http://chigby.org', title: 'chigby.org', type: 'portfolio', contact: 'me@chigby.org', author: 'Cameron Higby-Naquin' },
-  { url: 'https://longest.voyage' },
-  { url: 'https://palomakop.tv' },
-  { url: 'https://v-os.ca' },
-  { url: 'https://jmandel.xyz' },
-  { url: 'https://systems.ws' },
-  { url: 'https://2d4.dev', title: '2d4.dev', author: 'jda0', contact: 'hi@2d4.dev', feed: 'https://2d4.dev/tw.txt', wiki: 'https://2d4.dev/wiki.ndtl' },
-  { url: 'https://nathanwentworth.co' },
-  { url: 'https://uonai.space' },
-  { url: 'http://controls.ee' },
-  { url: 'https://wasin.io' },
-  { url: 'https://inns.studio' },
-  { url: 'http://kokorobot.ca' },
-  { url: 'https://ameyama.com', title: 'ameyama', type: 'blog', author: 'jrc03c', contact: 'josh@ameyama.com', rss: 'https://ameyama.com/blog/rss.xml', wiki: 'https://ameyama.com/data/wiki.ndtl' },
-  { url: 'https://wake.st', title: 'wake.st', author: 'wakest', contact: '@liaizon@wake.st', feed: 'https://wake.st/twtxt.txt' },
-  { url: 'https://xarene.la' },
-  { url: 'https://alex.zyzhang.me' },
-  { url: 'http://bildwissenschaft.vortok.info' },
-  { url: 'https://jakofranko.github.com' },
-  { url: 'https://aeriform.io' },
-  { url: 'http://blog.lucasdidthis.com' },
-  { url: 'http://npisanti.com', title: 'npisanti.com', author: 'npisanti', contact: 'nicola@npisanti.com', rss: 'http://npisanti.com/journal/rss.xml' },
-  { url: 'https://underscorediscovery.ca' },
-  { url: 'https://drisc.io', title: 'drisc.io', type: 'wiki', author: 'drisc', contact: 'cory@drisc.io', feed: 'https://drisc.io/hallway/twtxt.txt' },
-  { url: 'https://neufv.systems', author: 'neufv' },
-  { url: 'https://ricky.codes' },
-  { url: 'https://maxdeviant.com' },
-  { url: 'https://tynandebold.com' },
-  { url: 'http://gytis.co' },
-  { url: 'https://nomand.co' },
-  { url: 'http://memoriata.com' },
-  { url: 'https://mmm.s-ol.nu' },
-  { url: 'https://chad.is' },
-  { url: 'https://smidgeo.com/bots' },
-  { url: 'https://iko.soy' },
-  { url: 'http://atelieroilandsugar.com' },
-  { url: 'https://magoz.is' },
-  { url: 'https://szymonkaliski.com', author: 'Szymon Kaliski', type: 'hybrid', rss: 'https://szymonkaliski.com/feed.xml' },
-  { url: 'https://phse.net', title: 'phse.net', type: 'blog', author: 'setphen', rss: 'https://phse.net/post/index.xml', feed: 'https://phse.net/twtxt/merv.txt' },
-  { url: 'https://rosano.ca' },
-  { url: 'https://soyboysky.github.io' },
-  { url: 'https://gndclouds.cc' },
-  { url: 'https://xuv.be' },
-  { url: 'https://dsdshcym.github.io' },
-  { url: 'https://wiki.chronica.xyz', title: 'chronica', type: 'wiki', author: 'ckipp', contact: 'ckipp@pm.me', feed: 'https://chronica.xyz/hallway.txt', wiki: 'https://chronica.xyz/glossary.ndtl' },
-  { url: 'https://boffosocko.com' },
-  { url: 'https://hex22.org', title: 'hex22', author: 'kodedninja', contact: 'karamanhunor@pm.me', feed: 'https://t.seed.hex22.org/twtxt.txt' },
-  { url: 'https://patrikarvidsson.com' },
-  { url: 'https://sophieleetmaa.com' },
-  { url: 'https://xinniw.github.io' },
-  { url: 'https://mboxed.github.io/sodatsu', title: 'sodatsu', type: 'wiki', author: 'm', contact: 'mboxxed@gmail.com', feed: 'https://mboxed.github.io/sodatsu/tw.txt' },
-  { url: 'https://letters.vexingworkshop.com' },
-  { url: 'https://tom.org.nz', title: 'Tom Hackshaw', type: 'portfolio', author: 'tomupom', contact: 'tom@tomhackshaw.com', wiki: 'https://a.tom.org.nz/glossary.ndtl' },
-  { url: 'https://teknari.com' },
-  { url: 'https://colectivo-de-livecoders.gitlab.io', title: 'Colectivo de Livecoders', type: 'blog', author: 'clic', contact: 'https://t.me/clic_laplata' },
-  { url: 'https://www.madewithtea.com', title: 'madewithtea.com', type: 'blog' },
-  { url: 'https://amorris.ca', title: 'amorris', author: 'amorris', type: 'blog', feed: 'https://feed.amorris.ca/hallway.txt', wiki: 'https://wiki.amorris.ca/glossary.ndtl' },
-  { url: 'http://www.miha-co.ca', title: 'miha-co', type: 'portfolio' },
-  { url: 'https://buzzert.net', title: 'buzzert.net', author: 'buzzert', type: 'blog' },
-  { url: 'https://notes.stuartpb.com/', title: 'notes.stuartpb.com', type: 'wiki', author: 'stuartpb', contact: 's@stuartpb.com', feed: 'https://twtxt.stuartpb.com/xxiivv.txt' },
-  { url: 'https://xxiii.co', title: 'xxiii', type: 'portfolio', author: 'serocell', contact: 'psignal@s900.net', rss: 'https://serocell.com/feeds/serocell.xml', feed: 'https://xxiii.co/twtxt.txt' },
-  { url: 'https://kor.nz', title: 'kor', type: 'wiki', author: 'kormyen', contact: 'h@kor.nz', feed: 'https://kor.nz/twtxt.txt', wiki: 'https://kor.nz/db/glossary.ndtl' },
-  { url: 'https://lublin.se', author: 'quite', contact: 'quite@hack.org', feed: 'https://lublin.se/twtxt.txt' },
-  { url: 'https://zanneth.com', title: 'zanneth.com', author: 'zanneth', type: 'blog', contact: 'root@zanneth.com' },
-  { url: 'https://eli.li', title: 'eli.li', author: 'eli_oat', type: 'blog', contact: 'hi@eli.li', rss: 'https://eli.li/feed.rss', feed: 'https://txt.eli.li/twtxt/twtxt.txt' },
-  { url: 'https://gueorgui.net', title: 'Gueorgui Tcherednitchenko', author: 'gueorgui', type: 'portfolio', contact: 'hello@gueorgui.net' },
-  { url: 'https://www.gkbrk.com', title: 'Leo', author: 'Leo', type: 'blog', contact: 'webring@gkbrk.com', rss: 'https://www.gkbrk.com/feed.xml', feed: 'https://www.gkbrk.com/twtxt.txt' },
-  { url: 'https://www.tatecarson.com', title: 'Tate Carson', type: 'portfolio', author: 'Tate Carson', contact: 'tatecarson@gmail.com' },
-  { url: 'https://azlen.me', title: 'azlen.me', author: 'azlen', type: 'wiki', contact: 'webring@azlen.me', feed: 'https://azlen.me/twtxt.txt', wiki: 'https://azlen.me/glossary.ndtl' },
-  { url: 'https://opinionatedguide.github.io/', title: 'OpGuides', author: 'vega', contact: 'vegac@protonmail.com', feed: 'https://opinionatedguide.github.io/twtxt.txt' },
-  { url: 'https://chrismaughan.com/', title: 'CMaughan', author: 'cmaughan', contact: 'mornymorny@gmail.com', feed: 'https://chrismaughan.com/twtxt.txt' },
-  { url: 'https://oddworlds.org/', title: 'oddworlds soliloquy', type: 'blog', author: 'RaelZero', contact: 'gaz.gong@gmail.com' },
-  { url: 'https://fundor333.com/', title: 'Fundor333', type: 'blog', author: 'Fundor 333', contact: 'blog@fundor333.com', feed: 'https://fundor333.com/twtxt.txt' },
-  { url: 'https://cass.si/', contact: 'm@cass.si' },
-  { url: 'https://dotcomboom.somnolescent.net/', title: 'dotcomboom.somnolescent.net', author: 'dcb', contact: 'dotcomboom@somnolescent.net', feed: 'https://dotcomboom.somnolescent.net/twtxt.txt' },
-  { url: 'https://cadmican.neocities.org/', title: 'cadmican', contact: 'arachi@airmail.cc', author: 'Nihiltarier' },
-  { url: 'https://jskjott.com', title: 'jskjott', contact: 'jonathan@jskjott.com', author: 'Jonathan Skjøtt' },
-  { url: 'https://sixey.es/', title: 'sixey.es', contact: 'elmusho@gmail.com', author: 'sixeyes', type: 'portfolio' }
-]
+const sites =
+  [ { url: 'https://wiki.xxiivv.com'
+    , title: 'xxiivv'
+    , type: 'wiki'
+    , author: 'neauoire'
+    , contact: 'aliceffekt@gmail.com'
+    , rss: 'https://wiki.xxiivv.com/links/rss.xml'
+    , feed: 'https://wiki.xxiivv.com/twtxt.txt'
+    , wiki: 'https://wiki.xxiivv.com/scripts/database/glossary.ndtl'
+    }
+
+  , { url: 'http://estevancarlos.com' }
+
+  , { url: 'https://electro.pizza'
+    , title: 'electro pizza'
+    , type: 'blog'
+    , author: 'rho'
+    , rss: 'https://electro.pizza/feed.xml'
+    , feed: 'https://electro.pizza/twtxt.txt'
+    }
+
+  , { url: 'https://avanier.now.sh'
+    , title: 'Arachne'
+    , type: 'wiki'
+    , author: 'joshavanier'
+    , contact: 'joshavanier@protonmail.com'
+    , feed: 'https://avanier.now.sh/tw.txt'
+    }
+
+  , { url: 'http://kaemura.com'
+    , title: 'kaemura.com'
+    , type: 'blog'
+    , author: 'kaemura'
+    , contact: 'chimera1190@gmail.com'
+    , feed: 'https://kaemura.com/twttxt.txt'
+    }
+
+  , { url: 'https://liamcooke.com'
+    , title: 'liamcooke.com'
+    , author: 'slisne'
+    , contact: '@slisne@merveilles.town'
+    , rss: 'https://liamcooke.com/feed.xml'
+    , wiki: 'https://liamcooke.com/merveilles/wiki.ndtl'
+    , feed: 'https://liamcooke.com/merveilles/tw.txt'
+    }
+
+  , { url: 'https://electricgecko.de'
+    , title: 'electricgecko'
+    , type: 'blog'
+    , author: 'electricgecko'
+    , contact: 'desk@electricgecko.de'
+    , rss: 'https://electricgecko.de/feed'
+    }
+
+  , { url: 'https://wichniow.ski' }
+
+  , { url: 'https://hraew.autophagy.io' }
+
+  , { url: 'http://evenunto.net' }
+
+  , { url: 'https://anxl.faith' }
+
+  , { url: 'https://xvw.github.io'
+    , title: 'xvw.github.io'
+    , type: 'blog'
+    , author: 'xvw'
+    , contact: 'xaviervdw@gmail.com'
+    , rss: 'https://xvw.github.io/atom.xml'
+    }
+
+  , { url: 'https://heracl.es' }
+
+  , { url: 'http://luminghao.com' }
+
+  , { url: 'https://turelio.github.io' }
+
+  , { url: 'https://log.lectronice.com'
+    , title: 'lectrolog.'
+    , type: 'blog'
+    , author: 'lectronice'
+    , contact: 'i.love.spam@lectronice.com'
+    , feed: 'https://lectronice.com/hallway/twtxt.txt'
+    }
+
+  , { url: 'https://craze.co.uk' }
+
+  , { url: 'https://shaneckel.com' }
+
+  , { url: 'https://cblgh.org'
+    , title: 'cblgh.org'
+    , author: 'cblgh'
+    , contact: 'cabal://cblgh.org'
+    , feed: 'https://cblgh.org/twtxt.txt'
+    }
+
+  , { url: 'https://ellugar.co'
+    , title: 'ellugar'
+    , type: 'wiki'
+    , author: 'afk'
+    , contact: 'afk@ellugar.co'
+    , rss: 'http://feeds.ellugar.co/ellugar-logs'
+    }
+
+  , { url: 'http://chigby.org'
+    , title: 'chigby.org'
+    , type: 'portfolio'
+    , contact: 'me@chigby.org'
+    , author: 'Cameron Higby-Naquin'
+    }
+
+  , { url: 'https://longest.voyage' }
+
+  , { url: 'https://palomakop.tv' }
+
+  , { url: 'https://v-os.ca' }
+
+  , { url: 'https://jmandel.xyz' }
+
+  , { url: 'https://systems.ws' }
+
+  , { url: 'https://2d4.dev'
+    , title: '2d4.dev'
+    , author: 'jda0'
+    , contact: 'hi@2d4.dev'
+    , feed: 'https://2d4.dev/tw.txt'
+    , wiki: 'https://2d4.dev/wiki.ndtl'
+    }
+
+  , { url: 'https://nathanwentworth.co' }
+
+  , { url: 'https://uonai.space' }
+
+  , { url: 'http://controls.ee' }
+
+  , { url: 'https://wasin.io' }
+
+  , { url: 'https://inns.studio' }
+
+  , { url: 'http://kokorobot.ca' }
+
+  , { url: 'https://ameyama.com'
+    , title: 'ameyama'
+    , type: 'blog'
+    , author: 'jrc03c'
+    , contact: 'josh@ameyama.com'
+    , rss: 'https://ameyama.com/blog/rss.xml'
+    , wiki: 'https://ameyama.com/data/wiki.ndtl'
+    }
+
+  , { url: 'https://wake.st'
+    , title: 'wake.st'
+    , author: 'wakest'
+    , contact: '@liaizon@wake.st'
+    , feed: 'https://wake.st/twtxt.txt'
+    }
+
+  , { url: 'https://xarene.la' }
+
+  , { url: 'https://alex.zyzhang.me' }
+
+  , { url: 'http://bildwissenschaft.vortok.info' }
+
+  , { url: 'https://jakofranko.github.com' }
+
+  , { url: 'https://aeriform.io' }
+
+  , { url: 'http://blog.lucasdidthis.com' }
+
+  , { url: 'http://npisanti.com'
+    , title: 'npisanti.com'
+    , author: 'npisanti'
+    , contact: 'nicola@npisanti.com'
+    , rss: 'http://npisanti.com/journal/rss.xml'
+    }
+
+  , { url: 'https://underscorediscovery.ca' }
+
+  , { url: 'https://drisc.io'
+    , title: 'drisc.io'
+    , type: 'wiki'
+    , author: 'drisc'
+    , contact: 'cory@drisc.io'
+    , feed: 'https://drisc.io/hallway/twtxt.txt'
+    }
+
+  , { url: 'https://neufv.systems'
+    , author: 'neufv'
+    }
+
+  , { url: 'https://ricky.codes' }
+
+  , { url: 'https://maxdeviant.com' }
+
+  , { url: 'https://tynandebold.com' }
+
+  , { url: 'http://gytis.co' }
+
+  , { url: 'https://nomand.co' }
+
+  , { url: 'http://memoriata.com' }
+
+  , { url: 'https://mmm.s-ol.nu' }
+
+  , { url: 'https://chad.is' }
+
+  , { url: 'https://smidgeo.com/bots' }
+
+  , { url: 'https://iko.soy' }
+
+  , { url: 'http://atelieroilandsugar.com' }
+
+  , { url: 'https://magoz.is' }
+
+  , { url: 'https://szymonkaliski.com'
+    , author: 'Szymon Kaliski'
+    , type: 'hybrid'
+    , rss: 'https://szymonkaliski.com/feed.xml'
+    }
+
+  , { url: 'https://phse.net'
+    , title: 'phse.net'
+    , type: 'blog'
+    , author: 'setphen'
+    , rss: 'https://phse.net/post/index.xml'
+    , feed: 'https://phse.net/twtxt/merv.txt'
+    }
+
+  , { url: 'https://rosano.ca' }
+
+  , { url: 'https://soyboysky.github.io' }
+
+  , { url: 'https://gndclouds.cc' }
+
+  , { url: 'https://xuv.be' }
+
+  , { url: 'https://dsdshcym.github.io' }
+
+  , { url: 'https://wiki.chronica.xyz'
+    , title: 'chronica'
+    , type: 'wiki'
+    , author: 'ckipp'
+    , contact: 'ckipp@pm.me'
+    , feed: 'https://chronica.xyz/hallway.txt'
+    , wiki: 'https://chronica.xyz/glossary.ndtl'
+    }
+
+  , { url: 'https://boffosocko.com' }
+
+  , { url: 'https://hex22.org'
+    , title: 'hex22'
+    , author: 'kodedninja'
+    , contact: 'karamanhunor@pm.me'
+    , feed: 'https://t.seed.hex22.org/twtxt.txt'
+    }
+
+  , { url: 'https://patrikarvidsson.com' }
+
+  , { url: 'https://sophieleetmaa.com' }
+
+  , { url: 'https://xinniw.github.io' }
+
+  , { url: 'https://mboxed.github.io/sodatsu'
+    , title: 'sodatsu'
+    , type: 'wiki'
+    , author: 'm'
+    , contact: 'mboxxed@gmail.com'
+    , feed: 'https://mboxed.github.io/sodatsu/tw.txt'
+    }
+
+  , { url: 'https://letters.vexingworkshop.com' }
+
+  , { url: 'https://tom.org.nz'
+    , title: 'Tom Hackshaw'
+    , type: 'portfolio'
+    , author: 'tomupom'
+    , contact: 'tom@tomhackshaw.com'
+    , wiki: 'https://a.tom.org.nz/glossary.ndtl'
+    }
+
+  , { url: 'https://teknari.com' }
+
+  , { url: 'https://colectivo-de-livecoders.gitlab.io'
+    , title: 'Colectivo de Livecoders'
+    , type: 'blog'
+    , author: 'clic'
+    , contact: 'https://t.me/clic_laplata'
+    }
+
+  , { url: 'https://www.madewithtea.com'
+    , title: 'madewithtea.com'
+    , type: 'blog'
+    }
+
+  , { url: 'https://amorris.ca'
+    , title: 'amorris'
+    , author: 'amorris'
+    , type: 'blog'
+    , feed: 'https://feed.amorris.ca/hallway.txt'
+    , wiki: 'https://wiki.amorris.ca/glossary.ndtl'
+    }
+
+  , { url: 'http://www.miha-co.ca'
+    , title: 'miha-co'
+    , type: 'portfolio'
+    }
+
+  , { url: 'https://buzzert.net'
+    , title: 'buzzert.net'
+    , author: 'buzzert'
+    , type: 'blog'
+    }
+
+  , { url: 'https://notes.stuartpb.com/'
+    , title: 'notes.stuartpb.com'
+    , type: 'wiki'
+    , author: 'stuartpb'
+    , contact: 's@stuartpb.com'
+    , feed: 'https://twtxt.stuartpb.com/xxiivv.txt'
+    }
+
+  , { url: 'https://xxiii.co'
+    , title: 'xxiii'
+    , type: 'portfolio'
+    , author: 'serocell'
+    , contact: 'psignal@s900.net'
+    , rss: 'https://serocell.com/feeds/serocell.xml'
+    , feed: 'https://xxiii.co/twtxt.txt'
+    }
+
+  , { url: 'https://kor.nz'
+    , title: 'kor'
+    , type: 'wiki'
+    , author: 'kormyen'
+    , contact: 'h@kor.nz'
+    , feed: 'https://kor.nz/twtxt.txt'
+    , wiki: 'https://kor.nz/db/glossary.ndtl'
+    }
+
+  , { url: 'https://lublin.se'
+    , author: 'quite'
+    , contact: 'quite@hack.org'
+    , feed: 'https://lublin.se/twtxt.txt'
+    }
+
+  , { url: 'https://zanneth.com'
+    , title: 'zanneth.com'
+    , author: 'zanneth'
+    , type: 'blog'
+    , contact: 'root@zanneth.com'
+    }
+
+  , { url: 'https://eli.li'
+    , title: 'eli.li'
+    , author: 'eli_oat'
+    , type: 'blog'
+    , contact: 'hi@eli.li'
+    , rss: 'https://eli.li/feed.rss'
+    , feed: 'https://txt.eli.li/twtxt/twtxt.txt'
+    }
+
+  , { url: 'https://gueorgui.net'
+    , title: 'Gueorgui Tcherednitchenko'
+    , author: 'gueorgui'
+    , type: 'portfolio'
+    , contact: 'hello@gueorgui.net'
+    }
+
+  , { url: 'https://www.gkbrk.com'
+    , title: 'Leo'
+    , author: 'Leo'
+    , type: 'blog'
+    , contact: 'webring@gkbrk.com'
+    , rss: 'https://www.gkbrk.com/feed.xml'
+    , feed: 'https://www.gkbrk.com/twtxt.txt'
+    }
+
+  , { url: 'https://www.tatecarson.com'
+    , title: 'Tate Carson'
+    , type: 'portfolio'
+    , author: 'Tate Carson'
+    , contact: 'tatecarson@gmail.com'
+    }
+
+  , { url: 'https://azlen.me'
+    , title: 'azlen.me'
+    , author: 'azlen'
+    , type: 'wiki'
+    , contact: 'webring@azlen.me'
+    , feed: 'https://azlen.me/twtxt.txt'
+    , wiki: 'https://azlen.me/glossary.ndtl'
+    }
+
+  , { url: 'https://opinionatedguide.github.io/'
+    , title: 'OpGuides'
+    , author: 'vega'
+    , contact: 'vegac@protonmail.com'
+    , feed: 'https://opinionatedguide.github.io/twtxt.txt'
+    }
+
+  , { url: 'https://chrismaughan.com/'
+    , title: 'CMaughan'
+    , author: 'cmaughan'
+    , contact: 'mornymorny@gmail.com'
+    , feed: 'https://chrismaughan.com/twtxt.txt'
+    }
+
+  , { url: 'https://oddworlds.org/'
+    , title: 'oddworlds soliloquy'
+    , type: 'blog'
+    , author: 'RaelZero'
+    , contact: 'gaz.gong@gmail.com'
+    }
+
+  , { url: 'https://fundor333.com/'
+    , title: 'Fundor333'
+    , type: 'blog'
+    , author: 'Fundor 333'
+    , contact: 'blog@fundor333.com'
+    , feed: 'https://fundor333.com/twtxt.txt'
+    }
+
+  , { url: 'https://cass.si/'
+    , contact: 'm@cass.si'
+    }
+
+  , { url: 'https://dotcomboom.somnolescent.net/'
+    , title: 'dotcomboom.somnolescent.net'
+    , author: 'dcb'
+    , contact: 'dotcomboom@somnolescent.net'
+    , feed: 'https://dotcomboom.somnolescent.net/twtxt.txt'
+    }
+
+  , { url: 'https://cadmican.neocities.org/'
+    , title: 'cadmican'
+    , contact: 'arachi@airmail.cc'
+    , author: 'Nihiltarier'
+    }
+
+  , { url: 'https://jskjott.com'
+    , title: 'jskjott'
+    , contact: 'jonathan@jskjott.com'
+    , author: 'Jonathan Skjøtt'
+    }
+
+  , { url: 'https://sixey.es/'
+    , title: 'sixey.es'
+    , contact: 'elmusho@gmail.com'
+    , author: 'sixeyes'
+    , type: 'portfolio'
+    }
+
+  ]

--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -4,7 +4,8 @@
 // protocol://url.domain.ext
 
 const sites = [
-{ url: 'https://wiki.xxiivv.com',
+{
+  url: 'https://wiki.xxiivv.com',
   title: 'xxiivv',
   type: 'wiki',
   author: 'neauoire',
@@ -14,9 +15,12 @@ const sites = [
   wiki: 'https://wiki.xxiivv.com/scripts/database/glossary.ndtl',
 },
 
-{ url: 'http://estevancarlos.com' },
+{
+  url: 'http://estevancarlos.com'
+},
 
-{ url: 'https://electro.pizza',
+{
+  url: 'https://electro.pizza',
   title: 'electro pizza',
   type: 'blog',
   author: 'rho',
@@ -24,7 +28,8 @@ const sites = [
   feed: 'https://electro.pizza/twtxt.txt',
 },
 
-{ url: 'https://avanier.now.sh',
+{
+  url: 'https://avanier.now.sh',
   title: 'Arachne',
   type: 'wiki',
   author: 'joshavanier',
@@ -32,7 +37,8 @@ const sites = [
   feed: 'https://avanier.now.sh/tw.txt',
 },
 
-{ url: 'http://kaemura.com',
+{
+  url: 'http://kaemura.com',
   title: 'kaemura.com',
   type: 'blog',
   author: 'kaemura',
@@ -40,7 +46,8 @@ const sites = [
   feed: 'https://kaemura.com/twttxt.txt',
 },
 
-{ url: 'https://liamcooke.com',
+{
+  url: 'https://liamcooke.com',
   title: 'liamcooke.com',
   author: 'slisne',
   contact: '@slisne@merveilles.town',
@@ -49,7 +56,8 @@ const sites = [
   feed: 'https://liamcooke.com/merveilles/tw.txt',
 },
 
-{ url: 'https://electricgecko.de',
+{
+  url: 'https://electricgecko.de',
   title: 'electricgecko',
   type: 'blog',
   author: 'electricgecko',
@@ -57,15 +65,24 @@ const sites = [
   rss: 'https://electricgecko.de/feed',
 },
 
-{ url: 'https://wichniow.ski' },
+{
+  url: 'https://wichniow.ski'
+},
 
-{ url: 'https://hraew.autophagy.io' },
+{
+  url: 'https://hraew.autophagy.io'
+},
 
-{ url: 'http://evenunto.net' },
+{
+  url: 'http://evenunto.net'
+},
 
-{ url: 'https://anxl.faith' },
+{
+  url: 'https://anxl.faith'
+},
 
-{ url: 'https://xvw.github.io',
+{
+  url: 'https://xvw.github.io',
   title: 'xvw.github.io',
   type: 'blog',
   author: 'xvw',
@@ -73,13 +90,20 @@ const sites = [
   rss: 'https://xvw.github.io/atom.xml',
 },
 
-{ url: 'https://heracl.es' },
+{
+  url: 'https://heracl.es'
+},
 
-{ url: 'http://luminghao.com' },
+{
+  url: 'http://luminghao.com'
+},
 
-{ url: 'https://turelio.github.io' },
+{
+  url: 'https://turelio.github.io'
+},
 
-{ url: 'https://log.lectronice.com',
+{
+  url: 'https://log.lectronice.com',
   title: 'lectrolog.',
   type: 'blog',
   author: 'lectronice',
@@ -87,18 +111,24 @@ const sites = [
   feed: 'https://lectronice.com/hallway/twtxt.txt',
 },
 
-{ url: 'https://craze.co.uk' },
+{
+  url: 'https://craze.co.uk'
+},
 
-{ url: 'https://shaneckel.com' },
+{
+  url: 'https://shaneckel.com'
+},
 
-{ url: 'https://cblgh.org',
+{
+  url: 'https://cblgh.org',
   title: 'cblgh.org',
   author: 'cblgh',
   contact: 'cabal://cblgh.org',
   feed: 'https://cblgh.org/twtxt.txt',
 },
 
-{ url: 'https://ellugar.co',
+{
+  url: 'https://ellugar.co',
   title: 'ellugar',
   type: 'wiki',
   author: 'afk',
@@ -106,24 +136,36 @@ const sites = [
   rss: 'http://feeds.ellugar.co/ellugar-logs',
 },
 
-{ url: 'http://chigby.org',
+{
+  url: 'http://chigby.org',
   title: 'chigby.org',
   type: 'portfolio',
   contact: 'me@chigby.org',
   author: 'Cameron Higby-Naquin',
 },
 
-{ url: 'https://longest.voyage' },
+{
+  url: 'https://longest.voyage'
+},
 
-{ url: 'https://palomakop.tv' },
+{
+  url: 'https://palomakop.tv'
+},
 
-{ url: 'https://v-os.ca' },
+{
+  url: 'https://v-os.ca'
+},
 
-{ url: 'https://jmandel.xyz' },
+{
+  url: 'https://jmandel.xyz'
+},
 
-{ url: 'https://systems.ws' },
+{
+  url: 'https://systems.ws'
+},
 
-{ url: 'https://2d4.dev',
+{
+  url: 'https://2d4.dev',
   title: '2d4.dev',
   author: 'jda0',
   contact: 'hi@2d4.dev',
@@ -131,19 +173,32 @@ const sites = [
   wiki: 'https://2d4.dev/wiki.ndtl',
 },
 
-{ url: 'https://nathanwentworth.co' },
+{
+  url: 'https://nathanwentworth.co'
+},
 
-{ url: 'https://uonai.space' },
+{
+  url: 'https://uonai.space'
+},
 
-{ url: 'http://controls.ee' },
+{
+  url: 'http://controls.ee'
+},
 
-{ url: 'https://wasin.io' },
+{
+  url: 'https://wasin.io'
+},
 
-{ url: 'https://inns.studio' },
+{
+  url: 'https://inns.studio'
+},
 
-{ url: 'http://kokorobot.ca' },
+{
+  url: 'http://kokorobot.ca'
+},
 
-{ url: 'https://ameyama.com',
+{
+  url: 'https://ameyama.com',
   title: 'ameyama',
   type: 'blog',
   author: 'jrc03c',
@@ -152,35 +207,52 @@ const sites = [
   wiki: 'https://ameyama.com/data/wiki.ndtl',
 },
 
-{ url: 'https://wake.st',
+{
+  url: 'https://wake.st',
   title: 'wake.st',
   author: 'wakest',
   contact: '@liaizon@wake.st',
   feed: 'https://wake.st/twtxt.txt',
 },
 
-{ url: 'https://xarene.la' },
+{
+  url: 'https://xarene.la'
+},
 
-{ url: 'https://alex.zyzhang.me' },
+{
+  url: 'https://alex.zyzhang.me'
+},
 
-{ url: 'http://bildwissenschaft.vortok.info' },
+{
+  url: 'http://bildwissenschaft.vortok.info'
+},
 
-{ url: 'https://jakofranko.github.com' },
+{
+  url: 'https://jakofranko.github.com'
+},
 
-{ url: 'https://aeriform.io' },
+{
+  url: 'https://aeriform.io'
+},
 
-{ url: 'http://blog.lucasdidthis.com' },
+{
+  url: 'http://blog.lucasdidthis.com'
+},
 
-{ url: 'http://npisanti.com',
+{
+  url: 'http://npisanti.com',
   title: 'npisanti.com',
   author: 'npisanti',
   contact: 'nicola@npisanti.com',
   rss: 'http://npisanti.com/journal/rss.xml',
 },
 
-{ url: 'https://underscorediscovery.ca' },
+{
+  url: 'https://underscorediscovery.ca'
+},
 
-{ url: 'https://drisc.io',
+{
+  url: 'https://drisc.io',
   title: 'drisc.io',
   type: 'wiki',
   author: 'drisc',
@@ -188,41 +260,68 @@ const sites = [
   feed: 'https://drisc.io/hallway/twtxt.txt',
 },
 
-{ url: 'https://neufv.systems',
+{
+  url: 'https://neufv.systems',
   author: 'neufv',
 },
 
-{ url: 'https://ricky.codes' },
+{
+  url: 'https://ricky.codes'
+},
 
-{ url: 'https://maxdeviant.com' },
+{
+  url: 'https://maxdeviant.com'
+},
 
-{ url: 'https://tynandebold.com' },
+{
+  url: 'https://tynandebold.com'
+},
 
-{ url: 'http://gytis.co' },
+{
+  url: 'http://gytis.co'
+},
 
-{ url: 'https://nomand.co' },
+{
+  url: 'https://nomand.co'
+},
 
-{ url: 'http://memoriata.com' },
+{
+  url: 'http://memoriata.com'
+},
 
-{ url: 'https://mmm.s-ol.nu' },
+{
+  url: 'https://mmm.s-ol.nu'
+},
 
-{ url: 'https://chad.is' },
+{
+  url: 'https://chad.is'
+},
 
-{ url: 'https://smidgeo.com/bots' },
+{
+  url: 'https://smidgeo.com/bots'
+},
 
-{ url: 'https://iko.soy' },
+{
+  url: 'https://iko.soy'
+},
 
-{ url: 'http://atelieroilandsugar.com' },
+{
+  url: 'http://atelieroilandsugar.com'
+},
 
-{ url: 'https://magoz.is' },
+{
+  url: 'https://magoz.is'
+},
 
-{ url: 'https://szymonkaliski.com',
+{
+  url: 'https://szymonkaliski.com',
   author: 'Szymon Kaliski',
   type: 'hybrid',
   rss: 'https://szymonkaliski.com/feed.xml',
 },
 
-{ url: 'https://phse.net',
+{
+  url: 'https://phse.net',
   title: 'phse.net',
   type: 'blog',
   author: 'setphen',
@@ -230,17 +329,28 @@ const sites = [
   feed: 'https://phse.net/twtxt/merv.txt',
 },
 
-{ url: 'https://rosano.ca' },
+{
+  url: 'https://rosano.ca'
+},
 
-{ url: 'https://soyboysky.github.io' },
+{
+  url: 'https://soyboysky.github.io'
+},
 
-{ url: 'https://gndclouds.cc' },
+{
+  url: 'https://gndclouds.cc'
+},
 
-{ url: 'https://xuv.be' },
+{
+  url: 'https://xuv.be'
+},
 
-{ url: 'https://dsdshcym.github.io' },
+{
+  url: 'https://dsdshcym.github.io'
+},
 
-{ url: 'https://wiki.chronica.xyz',
+{
+  url: 'https://wiki.chronica.xyz',
   title: 'chronica',
   type: 'wiki',
   author: 'ckipp',
@@ -249,22 +359,32 @@ const sites = [
   wiki: 'https://chronica.xyz/glossary.ndtl',
 },
 
-{ url: 'https://boffosocko.com' },
+{
+  url: 'https://boffosocko.com'
+},
 
-{ url: 'https://hex22.org',
+{
+  url: 'https://hex22.org',
   title: 'hex22',
   author: 'kodedninja',
   contact: 'karamanhunor@pm.me',
   feed: 'https://t.seed.hex22.org/twtxt.txt',
 },
 
-{ url: 'https://patrikarvidsson.com' },
+{
+  url: 'https://patrikarvidsson.com'
+},
 
-{ url: 'https://sophieleetmaa.com' },
+{
+  url: 'https://sophieleetmaa.com'
+},
 
-{ url: 'https://xinniw.github.io' },
+{
+  url: 'https://xinniw.github.io'
+},
 
-{ url: 'https://mboxed.github.io/sodatsu',
+{
+  url: 'https://mboxed.github.io/sodatsu',
   title: 'sodatsu',
   type: 'wiki',
   author: 'm',
@@ -272,9 +392,12 @@ const sites = [
   feed: 'https://mboxed.github.io/sodatsu/tw.txt',
 },
 
-{ url: 'https://letters.vexingworkshop.com' },
+{
+  url: 'https://letters.vexingworkshop.com'
+},
 
-{ url: 'https://tom.org.nz',
+{
+  url: 'https://tom.org.nz',
   title: 'Tom Hackshaw',
   type: 'portfolio',
   author: 'tomupom',
@@ -282,21 +405,26 @@ const sites = [
   wiki: 'https://a.tom.org.nz/glossary.ndtl',
 },
 
-{ url: 'https://teknari.com' },
+{
+  url: 'https://teknari.com'
+},
 
-{ url: 'https://colectivo-de-livecoders.gitlab.io',
+{
+  url: 'https://colectivo-de-livecoders.gitlab.io',
   title: 'Colectivo de Livecoders',
   type: 'blog',
   author: 'clic',
   contact: 'https://t.me/clic_laplata',
 },
 
-{ url: 'https://www.madewithtea.com',
+{
+  url: 'https://www.madewithtea.com',
   title: 'madewithtea.com',
   type: 'blog',
 },
 
-{ url: 'https://amorris.ca',
+{
+  url: 'https://amorris.ca',
   title: 'amorris',
   author: 'amorris',
   type: 'blog',
@@ -304,18 +432,21 @@ const sites = [
   wiki: 'https://wiki.amorris.ca/glossary.ndtl',
 },
 
-{ url: 'http://www.miha-co.ca',
+{
+  url: 'http://www.miha-co.ca',
   title: 'miha-co',
   type: 'portfolio',
 },
 
-{ url: 'https://buzzert.net',
+{
+  url: 'https://buzzert.net',
   title: 'buzzert.net',
   author: 'buzzert',
   type: 'blog',
 },
 
-{ url: 'https://notes.stuartpb.com/',
+{
+  url: 'https://notes.stuartpb.com/',
   title: 'notes.stuartpb.com',
   type: 'wiki',
   author: 'stuartpb',
@@ -323,7 +454,8 @@ const sites = [
   feed: 'https://twtxt.stuartpb.com/xxiivv.txt',
 },
 
-{ url: 'https://xxiii.co',
+{
+  url: 'https://xxiii.co',
   title: 'xxiii',
   type: 'portfolio',
   author: 'serocell',
@@ -332,7 +464,8 @@ const sites = [
   feed: 'https://xxiii.co/twtxt.txt',
 },
 
-{ url: 'https://kor.nz',
+{
+  url: 'https://kor.nz',
   title: 'kor',
   type: 'wiki',
   author: 'kormyen',
@@ -341,20 +474,23 @@ const sites = [
   wiki: 'https://kor.nz/db/glossary.ndtl',
 },
 
-{ url: 'https://lublin.se',
+{
+  url: 'https://lublin.se',
   author: 'quite',
   contact: 'quite@hack.org',
   feed: 'https://lublin.se/twtxt.txt',
 },
 
-{ url: 'https://zanneth.com',
+{
+  url: 'https://zanneth.com',
   title: 'zanneth.com',
   author: 'zanneth',
   type: 'blog',
   contact: 'root@zanneth.com',
 },
 
-{ url: 'https://eli.li',
+{
+  url: 'https://eli.li',
   title: 'eli.li',
   author: 'eli_oat',
   type: 'blog',
@@ -363,14 +499,16 @@ const sites = [
   feed: 'https://txt.eli.li/twtxt/twtxt.txt',
 },
 
-{ url: 'https://gueorgui.net',
+{
+  url: 'https://gueorgui.net',
   title: 'Gueorgui Tcherednitchenko',
   author: 'gueorgui',
   type: 'portfolio',
   contact: 'hello@gueorgui.net',
 },
 
-{ url: 'https://www.gkbrk.com',
+{
+  url: 'https://www.gkbrk.com',
   title: 'Leo',
   author: 'Leo',
   type: 'blog',
@@ -379,14 +517,16 @@ const sites = [
   feed: 'https://www.gkbrk.com/twtxt.txt',
 },
 
-{ url: 'https://www.tatecarson.com',
+{
+  url: 'https://www.tatecarson.com',
   title: 'Tate Carson',
   type: 'portfolio',
   author: 'Tate Carson',
   contact: 'tatecarson@gmail.com',
 },
 
-{ url: 'https://azlen.me',
+{
+  url: 'https://azlen.me',
   title: 'azlen.me',
   author: 'azlen',
   type: 'wiki',
@@ -395,28 +535,32 @@ const sites = [
   wiki: 'https://azlen.me/glossary.ndtl',
 },
 
-{ url: 'https://opinionatedguide.github.io/',
+{
+  url: 'https://opinionatedguide.github.io/',
   title: 'OpGuides',
   author: 'vega',
   contact: 'vegac@protonmail.com',
   feed: 'https://opinionatedguide.github.io/twtxt.txt',
 },
 
-{ url: 'https://chrismaughan.com/',
+{
+  url: 'https://chrismaughan.com/',
   title: 'CMaughan',
   author: 'cmaughan',
   contact: 'mornymorny@gmail.com',
   feed: 'https://chrismaughan.com/twtxt.txt',
 },
 
-{ url: 'https://oddworlds.org/',
+{
+  url: 'https://oddworlds.org/',
   title: 'oddworlds soliloquy',
   type: 'blog',
   author: 'RaelZero',
   contact: 'gaz.gong@gmail.com',
 },
 
-{ url: 'https://fundor333.com/',
+{
+  url: 'https://fundor333.com/',
   title: 'Fundor333',
   type: 'blog',
   author: 'Fundor 333',
@@ -424,30 +568,35 @@ const sites = [
   feed: 'https://fundor333.com/twtxt.txt',
 },
 
-{ url: 'https://cass.si/',
+{
+  url: 'https://cass.si/',
   contact: 'm@cass.si',
 },
 
-{ url: 'https://dotcomboom.somnolescent.net/',
+{
+  url: 'https://dotcomboom.somnolescent.net/',
   title: 'dotcomboom.somnolescent.net',
   author: 'dcb',
   contact: 'dotcomboom@somnolescent.net',
   feed: 'https://dotcomboom.somnolescent.net/twtxt.txt',
 },
 
-{ url: 'https://cadmican.neocities.org/',
+{
+  url: 'https://cadmican.neocities.org/',
   title: 'cadmican',
   contact: 'arachi@airmail.cc',
   author: 'Nihiltarier',
 },
 
-{ url: 'https://jskjott.com',
+{
+  url: 'https://jskjott.com',
   title: 'jskjott',
   contact: 'jonathan@jskjott.com',
   author: 'Jonathan Skjøtt',
 },
 
-{ url: 'https://sixey.es/',
+{
+  url: 'https://sixey.es/',
   title: 'sixey.es',
   contact: 'elmusho@gmail.com',
   author: 'sixeyes',

--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -3,455 +3,455 @@
 // Don't forget the comma! No trailing slashes
 // protocol://url.domain.ext
 
-const sites =
-  [ { url: 'https://wiki.xxiivv.com'
-    , title: 'xxiivv'
-    , type: 'wiki'
-    , author: 'neauoire'
-    , contact: 'aliceffekt@gmail.com'
-    , rss: 'https://wiki.xxiivv.com/links/rss.xml'
-    , feed: 'https://wiki.xxiivv.com/twtxt.txt'
-    , wiki: 'https://wiki.xxiivv.com/scripts/database/glossary.ndtl'
-    }
-
-  , { url: 'http://estevancarlos.com' }
-
-  , { url: 'https://electro.pizza'
-    , title: 'electro pizza'
-    , type: 'blog'
-    , author: 'rho'
-    , rss: 'https://electro.pizza/feed.xml'
-    , feed: 'https://electro.pizza/twtxt.txt'
-    }
-
-  , { url: 'https://avanier.now.sh'
-    , title: 'Arachne'
-    , type: 'wiki'
-    , author: 'joshavanier'
-    , contact: 'joshavanier@protonmail.com'
-    , feed: 'https://avanier.now.sh/tw.txt'
-    }
-
-  , { url: 'http://kaemura.com'
-    , title: 'kaemura.com'
-    , type: 'blog'
-    , author: 'kaemura'
-    , contact: 'chimera1190@gmail.com'
-    , feed: 'https://kaemura.com/twttxt.txt'
-    }
-
-  , { url: 'https://liamcooke.com'
-    , title: 'liamcooke.com'
-    , author: 'slisne'
-    , contact: '@slisne@merveilles.town'
-    , rss: 'https://liamcooke.com/feed.xml'
-    , wiki: 'https://liamcooke.com/merveilles/wiki.ndtl'
-    , feed: 'https://liamcooke.com/merveilles/tw.txt'
-    }
-
-  , { url: 'https://electricgecko.de'
-    , title: 'electricgecko'
-    , type: 'blog'
-    , author: 'electricgecko'
-    , contact: 'desk@electricgecko.de'
-    , rss: 'https://electricgecko.de/feed'
-    }
-
-  , { url: 'https://wichniow.ski' }
-
-  , { url: 'https://hraew.autophagy.io' }
-
-  , { url: 'http://evenunto.net' }
-
-  , { url: 'https://anxl.faith' }
-
-  , { url: 'https://xvw.github.io'
-    , title: 'xvw.github.io'
-    , type: 'blog'
-    , author: 'xvw'
-    , contact: 'xaviervdw@gmail.com'
-    , rss: 'https://xvw.github.io/atom.xml'
-    }
-
-  , { url: 'https://heracl.es' }
-
-  , { url: 'http://luminghao.com' }
-
-  , { url: 'https://turelio.github.io' }
-
-  , { url: 'https://log.lectronice.com'
-    , title: 'lectrolog.'
-    , type: 'blog'
-    , author: 'lectronice'
-    , contact: 'i.love.spam@lectronice.com'
-    , feed: 'https://lectronice.com/hallway/twtxt.txt'
-    }
-
-  , { url: 'https://craze.co.uk' }
-
-  , { url: 'https://shaneckel.com' }
-
-  , { url: 'https://cblgh.org'
-    , title: 'cblgh.org'
-    , author: 'cblgh'
-    , contact: 'cabal://cblgh.org'
-    , feed: 'https://cblgh.org/twtxt.txt'
-    }
-
-  , { url: 'https://ellugar.co'
-    , title: 'ellugar'
-    , type: 'wiki'
-    , author: 'afk'
-    , contact: 'afk@ellugar.co'
-    , rss: 'http://feeds.ellugar.co/ellugar-logs'
-    }
+const sites = [
+{ url: 'https://wiki.xxiivv.com',
+  title: 'xxiivv',
+  type: 'wiki',
+  author: 'neauoire',
+  contact: 'aliceffekt@gmail.com',
+  rss: 'https://wiki.xxiivv.com/links/rss.xml',
+  feed: 'https://wiki.xxiivv.com/twtxt.txt',
+  wiki: 'https://wiki.xxiivv.com/scripts/database/glossary.ndtl',
+},
+
+{ url: 'http://estevancarlos.com' },
+
+{ url: 'https://electro.pizza',
+  title: 'electro pizza',
+  type: 'blog',
+  author: 'rho',
+  rss: 'https://electro.pizza/feed.xml',
+  feed: 'https://electro.pizza/twtxt.txt',
+},
+
+{ url: 'https://avanier.now.sh',
+  title: 'Arachne',
+  type: 'wiki',
+  author: 'joshavanier',
+  contact: 'joshavanier@protonmail.com',
+  feed: 'https://avanier.now.sh/tw.txt',
+},
+
+{ url: 'http://kaemura.com',
+  title: 'kaemura.com',
+  type: 'blog',
+  author: 'kaemura',
+  contact: 'chimera1190@gmail.com',
+  feed: 'https://kaemura.com/twttxt.txt',
+},
+
+{ url: 'https://liamcooke.com',
+  title: 'liamcooke.com',
+  author: 'slisne',
+  contact: '@slisne@merveilles.town',
+  rss: 'https://liamcooke.com/feed.xml',
+  wiki: 'https://liamcooke.com/merveilles/wiki.ndtl',
+  feed: 'https://liamcooke.com/merveilles/tw.txt',
+},
+
+{ url: 'https://electricgecko.de',
+  title: 'electricgecko',
+  type: 'blog',
+  author: 'electricgecko',
+  contact: 'desk@electricgecko.de',
+  rss: 'https://electricgecko.de/feed',
+},
+
+{ url: 'https://wichniow.ski' },
+
+{ url: 'https://hraew.autophagy.io' },
+
+{ url: 'http://evenunto.net' },
+
+{ url: 'https://anxl.faith' },
+
+{ url: 'https://xvw.github.io',
+  title: 'xvw.github.io',
+  type: 'blog',
+  author: 'xvw',
+  contact: 'xaviervdw@gmail.com',
+  rss: 'https://xvw.github.io/atom.xml',
+},
+
+{ url: 'https://heracl.es' },
+
+{ url: 'http://luminghao.com' },
+
+{ url: 'https://turelio.github.io' },
+
+{ url: 'https://log.lectronice.com',
+  title: 'lectrolog.',
+  type: 'blog',
+  author: 'lectronice',
+  contact: 'i.love.spam@lectronice.com',
+  feed: 'https://lectronice.com/hallway/twtxt.txt',
+},
+
+{ url: 'https://craze.co.uk' },
+
+{ url: 'https://shaneckel.com' },
+
+{ url: 'https://cblgh.org',
+  title: 'cblgh.org',
+  author: 'cblgh',
+  contact: 'cabal://cblgh.org',
+  feed: 'https://cblgh.org/twtxt.txt',
+},
+
+{ url: 'https://ellugar.co',
+  title: 'ellugar',
+  type: 'wiki',
+  author: 'afk',
+  contact: 'afk@ellugar.co',
+  rss: 'http://feeds.ellugar.co/ellugar-logs',
+},
 
-  , { url: 'http://chigby.org'
-    , title: 'chigby.org'
-    , type: 'portfolio'
-    , contact: 'me@chigby.org'
-    , author: 'Cameron Higby-Naquin'
-    }
+{ url: 'http://chigby.org',
+  title: 'chigby.org',
+  type: 'portfolio',
+  contact: 'me@chigby.org',
+  author: 'Cameron Higby-Naquin',
+},
 
-  , { url: 'https://longest.voyage' }
+{ url: 'https://longest.voyage' },
 
-  , { url: 'https://palomakop.tv' }
+{ url: 'https://palomakop.tv' },
 
-  , { url: 'https://v-os.ca' }
+{ url: 'https://v-os.ca' },
 
-  , { url: 'https://jmandel.xyz' }
+{ url: 'https://jmandel.xyz' },
 
-  , { url: 'https://systems.ws' }
+{ url: 'https://systems.ws' },
 
-  , { url: 'https://2d4.dev'
-    , title: '2d4.dev'
-    , author: 'jda0'
-    , contact: 'hi@2d4.dev'
-    , feed: 'https://2d4.dev/tw.txt'
-    , wiki: 'https://2d4.dev/wiki.ndtl'
-    }
+{ url: 'https://2d4.dev',
+  title: '2d4.dev',
+  author: 'jda0',
+  contact: 'hi@2d4.dev',
+  feed: 'https://2d4.dev/tw.txt',
+  wiki: 'https://2d4.dev/wiki.ndtl',
+},
 
-  , { url: 'https://nathanwentworth.co' }
+{ url: 'https://nathanwentworth.co' },
 
-  , { url: 'https://uonai.space' }
+{ url: 'https://uonai.space' },
 
-  , { url: 'http://controls.ee' }
+{ url: 'http://controls.ee' },
 
-  , { url: 'https://wasin.io' }
+{ url: 'https://wasin.io' },
 
-  , { url: 'https://inns.studio' }
+{ url: 'https://inns.studio' },
 
-  , { url: 'http://kokorobot.ca' }
+{ url: 'http://kokorobot.ca' },
 
-  , { url: 'https://ameyama.com'
-    , title: 'ameyama'
-    , type: 'blog'
-    , author: 'jrc03c'
-    , contact: 'josh@ameyama.com'
-    , rss: 'https://ameyama.com/blog/rss.xml'
-    , wiki: 'https://ameyama.com/data/wiki.ndtl'
-    }
+{ url: 'https://ameyama.com',
+  title: 'ameyama',
+  type: 'blog',
+  author: 'jrc03c',
+  contact: 'josh@ameyama.com',
+  rss: 'https://ameyama.com/blog/rss.xml',
+  wiki: 'https://ameyama.com/data/wiki.ndtl',
+},
 
-  , { url: 'https://wake.st'
-    , title: 'wake.st'
-    , author: 'wakest'
-    , contact: '@liaizon@wake.st'
-    , feed: 'https://wake.st/twtxt.txt'
-    }
+{ url: 'https://wake.st',
+  title: 'wake.st',
+  author: 'wakest',
+  contact: '@liaizon@wake.st',
+  feed: 'https://wake.st/twtxt.txt',
+},
 
-  , { url: 'https://xarene.la' }
+{ url: 'https://xarene.la' },
 
-  , { url: 'https://alex.zyzhang.me' }
+{ url: 'https://alex.zyzhang.me' },
 
-  , { url: 'http://bildwissenschaft.vortok.info' }
+{ url: 'http://bildwissenschaft.vortok.info' },
 
-  , { url: 'https://jakofranko.github.com' }
+{ url: 'https://jakofranko.github.com' },
 
-  , { url: 'https://aeriform.io' }
+{ url: 'https://aeriform.io' },
 
-  , { url: 'http://blog.lucasdidthis.com' }
+{ url: 'http://blog.lucasdidthis.com' },
 
-  , { url: 'http://npisanti.com'
-    , title: 'npisanti.com'
-    , author: 'npisanti'
-    , contact: 'nicola@npisanti.com'
-    , rss: 'http://npisanti.com/journal/rss.xml'
-    }
+{ url: 'http://npisanti.com',
+  title: 'npisanti.com',
+  author: 'npisanti',
+  contact: 'nicola@npisanti.com',
+  rss: 'http://npisanti.com/journal/rss.xml',
+},
 
-  , { url: 'https://underscorediscovery.ca' }
+{ url: 'https://underscorediscovery.ca' },
 
-  , { url: 'https://drisc.io'
-    , title: 'drisc.io'
-    , type: 'wiki'
-    , author: 'drisc'
-    , contact: 'cory@drisc.io'
-    , feed: 'https://drisc.io/hallway/twtxt.txt'
-    }
+{ url: 'https://drisc.io',
+  title: 'drisc.io',
+  type: 'wiki',
+  author: 'drisc',
+  contact: 'cory@drisc.io',
+  feed: 'https://drisc.io/hallway/twtxt.txt',
+},
 
-  , { url: 'https://neufv.systems'
-    , author: 'neufv'
-    }
+{ url: 'https://neufv.systems',
+  author: 'neufv',
+},
 
-  , { url: 'https://ricky.codes' }
+{ url: 'https://ricky.codes' },
 
-  , { url: 'https://maxdeviant.com' }
+{ url: 'https://maxdeviant.com' },
 
-  , { url: 'https://tynandebold.com' }
+{ url: 'https://tynandebold.com' },
 
-  , { url: 'http://gytis.co' }
+{ url: 'http://gytis.co' },
 
-  , { url: 'https://nomand.co' }
+{ url: 'https://nomand.co' },
 
-  , { url: 'http://memoriata.com' }
+{ url: 'http://memoriata.com' },
 
-  , { url: 'https://mmm.s-ol.nu' }
+{ url: 'https://mmm.s-ol.nu' },
 
-  , { url: 'https://chad.is' }
+{ url: 'https://chad.is' },
 
-  , { url: 'https://smidgeo.com/bots' }
+{ url: 'https://smidgeo.com/bots' },
 
-  , { url: 'https://iko.soy' }
+{ url: 'https://iko.soy' },
 
-  , { url: 'http://atelieroilandsugar.com' }
+{ url: 'http://atelieroilandsugar.com' },
 
-  , { url: 'https://magoz.is' }
+{ url: 'https://magoz.is' },
 
-  , { url: 'https://szymonkaliski.com'
-    , author: 'Szymon Kaliski'
-    , type: 'hybrid'
-    , rss: 'https://szymonkaliski.com/feed.xml'
-    }
+{ url: 'https://szymonkaliski.com',
+  author: 'Szymon Kaliski',
+  type: 'hybrid',
+  rss: 'https://szymonkaliski.com/feed.xml',
+},
 
-  , { url: 'https://phse.net'
-    , title: 'phse.net'
-    , type: 'blog'
-    , author: 'setphen'
-    , rss: 'https://phse.net/post/index.xml'
-    , feed: 'https://phse.net/twtxt/merv.txt'
-    }
+{ url: 'https://phse.net',
+  title: 'phse.net',
+  type: 'blog',
+  author: 'setphen',
+  rss: 'https://phse.net/post/index.xml',
+  feed: 'https://phse.net/twtxt/merv.txt',
+},
 
-  , { url: 'https://rosano.ca' }
+{ url: 'https://rosano.ca' },
 
-  , { url: 'https://soyboysky.github.io' }
+{ url: 'https://soyboysky.github.io' },
 
-  , { url: 'https://gndclouds.cc' }
+{ url: 'https://gndclouds.cc' },
 
-  , { url: 'https://xuv.be' }
+{ url: 'https://xuv.be' },
 
-  , { url: 'https://dsdshcym.github.io' }
+{ url: 'https://dsdshcym.github.io' },
 
-  , { url: 'https://wiki.chronica.xyz'
-    , title: 'chronica'
-    , type: 'wiki'
-    , author: 'ckipp'
-    , contact: 'ckipp@pm.me'
-    , feed: 'https://chronica.xyz/hallway.txt'
-    , wiki: 'https://chronica.xyz/glossary.ndtl'
-    }
+{ url: 'https://wiki.chronica.xyz',
+  title: 'chronica',
+  type: 'wiki',
+  author: 'ckipp',
+  contact: 'ckipp@pm.me',
+  feed: 'https://chronica.xyz/hallway.txt',
+  wiki: 'https://chronica.xyz/glossary.ndtl',
+},
 
-  , { url: 'https://boffosocko.com' }
+{ url: 'https://boffosocko.com' },
 
-  , { url: 'https://hex22.org'
-    , title: 'hex22'
-    , author: 'kodedninja'
-    , contact: 'karamanhunor@pm.me'
-    , feed: 'https://t.seed.hex22.org/twtxt.txt'
-    }
+{ url: 'https://hex22.org',
+  title: 'hex22',
+  author: 'kodedninja',
+  contact: 'karamanhunor@pm.me',
+  feed: 'https://t.seed.hex22.org/twtxt.txt',
+},
 
-  , { url: 'https://patrikarvidsson.com' }
+{ url: 'https://patrikarvidsson.com' },
 
-  , { url: 'https://sophieleetmaa.com' }
+{ url: 'https://sophieleetmaa.com' },
 
-  , { url: 'https://xinniw.github.io' }
+{ url: 'https://xinniw.github.io' },
 
-  , { url: 'https://mboxed.github.io/sodatsu'
-    , title: 'sodatsu'
-    , type: 'wiki'
-    , author: 'm'
-    , contact: 'mboxxed@gmail.com'
-    , feed: 'https://mboxed.github.io/sodatsu/tw.txt'
-    }
+{ url: 'https://mboxed.github.io/sodatsu',
+  title: 'sodatsu',
+  type: 'wiki',
+  author: 'm',
+  contact: 'mboxxed@gmail.com',
+  feed: 'https://mboxed.github.io/sodatsu/tw.txt',
+},
 
-  , { url: 'https://letters.vexingworkshop.com' }
-
-  , { url: 'https://tom.org.nz'
-    , title: 'Tom Hackshaw'
-    , type: 'portfolio'
-    , author: 'tomupom'
-    , contact: 'tom@tomhackshaw.com'
-    , wiki: 'https://a.tom.org.nz/glossary.ndtl'
-    }
-
-  , { url: 'https://teknari.com' }
-
-  , { url: 'https://colectivo-de-livecoders.gitlab.io'
-    , title: 'Colectivo de Livecoders'
-    , type: 'blog'
-    , author: 'clic'
-    , contact: 'https://t.me/clic_laplata'
-    }
-
-  , { url: 'https://www.madewithtea.com'
-    , title: 'madewithtea.com'
-    , type: 'blog'
-    }
-
-  , { url: 'https://amorris.ca'
-    , title: 'amorris'
-    , author: 'amorris'
-    , type: 'blog'
-    , feed: 'https://feed.amorris.ca/hallway.txt'
-    , wiki: 'https://wiki.amorris.ca/glossary.ndtl'
-    }
-
-  , { url: 'http://www.miha-co.ca'
-    , title: 'miha-co'
-    , type: 'portfolio'
-    }
-
-  , { url: 'https://buzzert.net'
-    , title: 'buzzert.net'
-    , author: 'buzzert'
-    , type: 'blog'
-    }
-
-  , { url: 'https://notes.stuartpb.com/'
-    , title: 'notes.stuartpb.com'
-    , type: 'wiki'
-    , author: 'stuartpb'
-    , contact: 's@stuartpb.com'
-    , feed: 'https://twtxt.stuartpb.com/xxiivv.txt'
-    }
-
-  , { url: 'https://xxiii.co'
-    , title: 'xxiii'
-    , type: 'portfolio'
-    , author: 'serocell'
-    , contact: 'psignal@s900.net'
-    , rss: 'https://serocell.com/feeds/serocell.xml'
-    , feed: 'https://xxiii.co/twtxt.txt'
-    }
-
-  , { url: 'https://kor.nz'
-    , title: 'kor'
-    , type: 'wiki'
-    , author: 'kormyen'
-    , contact: 'h@kor.nz'
-    , feed: 'https://kor.nz/twtxt.txt'
-    , wiki: 'https://kor.nz/db/glossary.ndtl'
-    }
-
-  , { url: 'https://lublin.se'
-    , author: 'quite'
-    , contact: 'quite@hack.org'
-    , feed: 'https://lublin.se/twtxt.txt'
-    }
-
-  , { url: 'https://zanneth.com'
-    , title: 'zanneth.com'
-    , author: 'zanneth'
-    , type: 'blog'
-    , contact: 'root@zanneth.com'
-    }
-
-  , { url: 'https://eli.li'
-    , title: 'eli.li'
-    , author: 'eli_oat'
-    , type: 'blog'
-    , contact: 'hi@eli.li'
-    , rss: 'https://eli.li/feed.rss'
-    , feed: 'https://txt.eli.li/twtxt/twtxt.txt'
-    }
-
-  , { url: 'https://gueorgui.net'
-    , title: 'Gueorgui Tcherednitchenko'
-    , author: 'gueorgui'
-    , type: 'portfolio'
-    , contact: 'hello@gueorgui.net'
-    }
-
-  , { url: 'https://www.gkbrk.com'
-    , title: 'Leo'
-    , author: 'Leo'
-    , type: 'blog'
-    , contact: 'webring@gkbrk.com'
-    , rss: 'https://www.gkbrk.com/feed.xml'
-    , feed: 'https://www.gkbrk.com/twtxt.txt'
-    }
-
-  , { url: 'https://www.tatecarson.com'
-    , title: 'Tate Carson'
-    , type: 'portfolio'
-    , author: 'Tate Carson'
-    , contact: 'tatecarson@gmail.com'
-    }
-
-  , { url: 'https://azlen.me'
-    , title: 'azlen.me'
-    , author: 'azlen'
-    , type: 'wiki'
-    , contact: 'webring@azlen.me'
-    , feed: 'https://azlen.me/twtxt.txt'
-    , wiki: 'https://azlen.me/glossary.ndtl'
-    }
-
-  , { url: 'https://opinionatedguide.github.io/'
-    , title: 'OpGuides'
-    , author: 'vega'
-    , contact: 'vegac@protonmail.com'
-    , feed: 'https://opinionatedguide.github.io/twtxt.txt'
-    }
-
-  , { url: 'https://chrismaughan.com/'
-    , title: 'CMaughan'
-    , author: 'cmaughan'
-    , contact: 'mornymorny@gmail.com'
-    , feed: 'https://chrismaughan.com/twtxt.txt'
-    }
-
-  , { url: 'https://oddworlds.org/'
-    , title: 'oddworlds soliloquy'
-    , type: 'blog'
-    , author: 'RaelZero'
-    , contact: 'gaz.gong@gmail.com'
-    }
-
-  , { url: 'https://fundor333.com/'
-    , title: 'Fundor333'
-    , type: 'blog'
-    , author: 'Fundor 333'
-    , contact: 'blog@fundor333.com'
-    , feed: 'https://fundor333.com/twtxt.txt'
-    }
-
-  , { url: 'https://cass.si/'
-    , contact: 'm@cass.si'
-    }
-
-  , { url: 'https://dotcomboom.somnolescent.net/'
-    , title: 'dotcomboom.somnolescent.net'
-    , author: 'dcb'
-    , contact: 'dotcomboom@somnolescent.net'
-    , feed: 'https://dotcomboom.somnolescent.net/twtxt.txt'
-    }
-
-  , { url: 'https://cadmican.neocities.org/'
-    , title: 'cadmican'
-    , contact: 'arachi@airmail.cc'
-    , author: 'Nihiltarier'
-    }
-
-  , { url: 'https://jskjott.com'
-    , title: 'jskjott'
-    , contact: 'jonathan@jskjott.com'
-    , author: 'Jonathan Skjøtt'
-    }
-
-  , { url: 'https://sixey.es/'
-    , title: 'sixey.es'
-    , contact: 'elmusho@gmail.com'
-    , author: 'sixeyes'
-    , type: 'portfolio'
-    }
-
-  ]
+{ url: 'https://letters.vexingworkshop.com' },
+
+{ url: 'https://tom.org.nz',
+  title: 'Tom Hackshaw',
+  type: 'portfolio',
+  author: 'tomupom',
+  contact: 'tom@tomhackshaw.com',
+  wiki: 'https://a.tom.org.nz/glossary.ndtl',
+},
+
+{ url: 'https://teknari.com' },
+
+{ url: 'https://colectivo-de-livecoders.gitlab.io',
+  title: 'Colectivo de Livecoders',
+  type: 'blog',
+  author: 'clic',
+  contact: 'https://t.me/clic_laplata',
+},
+
+{ url: 'https://www.madewithtea.com',
+  title: 'madewithtea.com',
+  type: 'blog',
+},
+
+{ url: 'https://amorris.ca',
+  title: 'amorris',
+  author: 'amorris',
+  type: 'blog',
+  feed: 'https://feed.amorris.ca/hallway.txt',
+  wiki: 'https://wiki.amorris.ca/glossary.ndtl',
+},
+
+{ url: 'http://www.miha-co.ca',
+  title: 'miha-co',
+  type: 'portfolio',
+},
+
+{ url: 'https://buzzert.net',
+  title: 'buzzert.net',
+  author: 'buzzert',
+  type: 'blog',
+},
+
+{ url: 'https://notes.stuartpb.com/',
+  title: 'notes.stuartpb.com',
+  type: 'wiki',
+  author: 'stuartpb',
+  contact: 's@stuartpb.com',
+  feed: 'https://twtxt.stuartpb.com/xxiivv.txt',
+},
+
+{ url: 'https://xxiii.co',
+  title: 'xxiii',
+  type: 'portfolio',
+  author: 'serocell',
+  contact: 'psignal@s900.net',
+  rss: 'https://serocell.com/feeds/serocell.xml',
+  feed: 'https://xxiii.co/twtxt.txt',
+},
+
+{ url: 'https://kor.nz',
+  title: 'kor',
+  type: 'wiki',
+  author: 'kormyen',
+  contact: 'h@kor.nz',
+  feed: 'https://kor.nz/twtxt.txt',
+  wiki: 'https://kor.nz/db/glossary.ndtl',
+},
+
+{ url: 'https://lublin.se',
+  author: 'quite',
+  contact: 'quite@hack.org',
+  feed: 'https://lublin.se/twtxt.txt',
+},
+
+{ url: 'https://zanneth.com',
+  title: 'zanneth.com',
+  author: 'zanneth',
+  type: 'blog',
+  contact: 'root@zanneth.com',
+},
+
+{ url: 'https://eli.li',
+  title: 'eli.li',
+  author: 'eli_oat',
+  type: 'blog',
+  contact: 'hi@eli.li',
+  rss: 'https://eli.li/feed.rss',
+  feed: 'https://txt.eli.li/twtxt/twtxt.txt',
+},
+
+{ url: 'https://gueorgui.net',
+  title: 'Gueorgui Tcherednitchenko',
+  author: 'gueorgui',
+  type: 'portfolio',
+  contact: 'hello@gueorgui.net',
+},
+
+{ url: 'https://www.gkbrk.com',
+  title: 'Leo',
+  author: 'Leo',
+  type: 'blog',
+  contact: 'webring@gkbrk.com',
+  rss: 'https://www.gkbrk.com/feed.xml',
+  feed: 'https://www.gkbrk.com/twtxt.txt',
+},
+
+{ url: 'https://www.tatecarson.com',
+  title: 'Tate Carson',
+  type: 'portfolio',
+  author: 'Tate Carson',
+  contact: 'tatecarson@gmail.com',
+},
+
+{ url: 'https://azlen.me',
+  title: 'azlen.me',
+  author: 'azlen',
+  type: 'wiki',
+  contact: 'webring@azlen.me',
+  feed: 'https://azlen.me/twtxt.txt',
+  wiki: 'https://azlen.me/glossary.ndtl',
+},
+
+{ url: 'https://opinionatedguide.github.io/',
+  title: 'OpGuides',
+  author: 'vega',
+  contact: 'vegac@protonmail.com',
+  feed: 'https://opinionatedguide.github.io/twtxt.txt',
+},
+
+{ url: 'https://chrismaughan.com/',
+  title: 'CMaughan',
+  author: 'cmaughan',
+  contact: 'mornymorny@gmail.com',
+  feed: 'https://chrismaughan.com/twtxt.txt',
+},
+
+{ url: 'https://oddworlds.org/',
+  title: 'oddworlds soliloquy',
+  type: 'blog',
+  author: 'RaelZero',
+  contact: 'gaz.gong@gmail.com',
+},
+
+{ url: 'https://fundor333.com/',
+  title: 'Fundor333',
+  type: 'blog',
+  author: 'Fundor 333',
+  contact: 'blog@fundor333.com',
+  feed: 'https://fundor333.com/twtxt.txt',
+},
+
+{ url: 'https://cass.si/',
+  contact: 'm@cass.si',
+},
+
+{ url: 'https://dotcomboom.somnolescent.net/',
+  title: 'dotcomboom.somnolescent.net',
+  author: 'dcb',
+  contact: 'dotcomboom@somnolescent.net',
+  feed: 'https://dotcomboom.somnolescent.net/twtxt.txt',
+},
+
+{ url: 'https://cadmican.neocities.org/',
+  title: 'cadmican',
+  contact: 'arachi@airmail.cc',
+  author: 'Nihiltarier',
+},
+
+{ url: 'https://jskjott.com',
+  title: 'jskjott',
+  contact: 'jonathan@jskjott.com',
+  author: 'Jonathan Skjøtt',
+},
+
+{ url: 'https://sixey.es/',
+  title: 'sixey.es',
+  contact: 'elmusho@gmail.com',
+  author: 'sixeyes',
+  type: 'portfolio',
+},
+
+]


### PR DESCRIPTION
this PR re-implementes "commas-first" structre, first proposed and approved in #39
( https://github.com/XXIIVV/Webring/commit/3a75ddaf60ff22c567a4d84e958e912dcd1fe343#diff-eacf331f0ffc35d4b482f1d15a887d3b )

re-formated sites.js, to make it human-readable;
this will also make future editing (like adding site-types) simplier and clearer.

order and functionality stayed unchanged.
