### PR TITLE
fix firefox redirect issue

### DIFF
--- a/scripts/hallway.js
+++ b/scripts/hallway.js
@@ -18,8 +18,8 @@ function Hallway (sites) {
   this._main.id = 'entries'
   this._footer = document.createElement('footer')
   this._footer.id = 'footer'
-  this.readme = `<p>The <strong>Hallway</strong> is a decentralized forum, to join the conversation, add a <a href="https://github.com/XXIIVV/webring#joining-the-hallway">feed:</a> field to your entry in the <a href="https://github.com/XXIIVV/Webring/">webring</a>.</p>`
-  this.nav = `<p class='buttons'><a href='https://github.com/XXIIVV/webring'>Information</a> | <a href="index.html">The Portal</a>  | <a href="wiki.html">The Wiki</a> | <a id="opml">OPML</a></p>`
+  this.readme = '<p>The <strong>Hallway</strong> is a decentralized forum, to join the conversation, add a <a href="https://github.com/XXIIVV/webring#joining-the-hallway">feed:</a> field to your entry in the <a href="https://github.com/XXIIVV/Webring/">webring</a>.</p>'
+  this.nav = '<p class="buttons"><a href="https://github.com/XXIIVV/webring">Information</a> | <a href="index.html">The Portal</a>  | <a href="wiki.html">The Wiki</a> | <a id="opml">OPML</a></p>'
   this._footer.innerHTML = `${this.readme}${this.nav}`
 
   this.install = function (host) {
@@ -118,10 +118,10 @@ function Hallway (sites) {
 
   this.templateEntry = function (entry) {
     entry.html = entry.body
-      .replace(reChannel, `$1<span class='channel'>/$2</span>`)
+      .replace(reChannel, '$1<span class="channel">/$2</span>')
       .replace(reUser, this.findMention)
       .replace(reTag, '$1<span class="tag">$2</span>')
-      .replace(reUrl, `<a target="_blank" href='$1'>$1</a>`)
+      .replace(reUrl, '<a target="_blank" href="$1">$1</a>')
 
     const filter = window.location.hash.substr(1).replace(/\+/g, ' ').toLowerCase()
     const highlight = filter === entry.author.toLowerCase()

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -8,18 +8,18 @@ function Portal (sites) {
   // Templates
 
   function _readme () {
-    return `<p class='readme'>This webring is an attempt to inspire artists & developers to build their own website and share traffic among each other. The ring welcomes personalized websites such as <b>diaries, wikis & portfolios</b>.</p><p>To add yourself to the ring, submit a <a href='https://github.com/XXIIVV/webring/edit/master/scripts/sites.js' target='_blank'>Pull Request</a>.<br />If you found a broken link, please <a href='https://github.com/XXIIVV/webring/issues/new' target='_blank'>report it</a>.</p>`
+    return '<p class="readme">This webring is an attempt to inspire artists & developers to build their own website and share traffic among each other. The ring welcomes personalized websites such as <b>diaries, wikis & portfolios</b>.</p><p>To add yourself to the ring, submit a <a href="https://github.com/XXIIVV/webring/edit/master/scripts/sites.js" target="_blank">Pull Request</a>.<br />If you found a broken link, please <a href="https://github.com/XXIIVV/webring/issues/new" target="_blank">report it</a>.</p>'
   }
 
   function _buttons () {
-    return `<p class='buttons'><a href='#random' onClick="portal.reload('random')">Random</a> | <a href='https://github.com/XXIIVV/webring'>Information</a> <a id='icon' href='#random' onClick="portal.reload('random')"></a> | <a href="hallway.html">The Hallway</a> | <a href="wiki.html">The Wiki</a> | <a id="opml">OPML</a></p>`
+    return '<p class="buttons"><a href="#random" onClick="portal.reload()">Random</a> | <a href="https://github.com/XXIIVV/webring">Information</a> <a id="icon" href="#random" onClick="portal.reload()"></a> | <a href="hallway.html">The Hallway</a> | <a href="wiki.html">The Wiki</a> | <a id="opml">OPML</a></p>'
   }
 
   function _directory (sites) {
     const siteTypesArray = [...new Set(sites.map(site => site.type).filter(Boolean))]
     const siteTypes = siteTypesArray.reduce((output, siteType) =>
-      `${output}<a data-type='${siteType}' href='#' onclick='toggleType(event)'>&lt;${siteType}&gt;</a>`,
-      `<a class='current' href='#' onclick='toggleType(event)'>&lt;all&gt;</a>`)
+      `${output}<a data-type="${siteType}" href="#" onclick="toggleType(event)">&lt;${siteType}&gt;</a>`,
+      '<a class="current" href="#" onclick="toggleType(event)">&lt;all&gt;</a>')
     const listItems = sites.reduce((acc, site, id) =>
       `${acc}<li ${_type(site)} id='${id}'><a href='${site.url}'>${_name(site)}</a></li>`, '')
     return `<nav>${siteTypes}</nav><main><ul>${listItems}</ul></main><footer>${_readme()}${_buttons()}</footer>`
@@ -35,8 +35,7 @@ function Portal (sites) {
 
   function _redirect (site) {
     return `<main><p>Redirecting to <a href="${site.url}">${site.url}</a></p></main>
-      <meta http-equiv="refresh" content="3; url=${site.url}">
-      <footer><p class='buttons'><a href='#' onClick="portal.reload('')">Directory</a> | <a href='#${site.url}' onClick="portal.reload('random')">Skip</a> | <a href='#random' onClick="portal.reload('random')">Random</a> | <a href='https://github.com/XXIIVV/webring'>Information</a> <a id='icon'  href='#random' onClick="portal.reload('random')"></a></p>`
+      <footer><p class='buttons'><a href='#' onClick="portal.reload('')">Directory</a> | <a href='#${site.url}' onClick="portal.reload()">Skip</a> | <a href='#random' onClick="portal.reload()">Random</a> | <a href='https://github.com/XXIIVV/webring'>Information</a> <a id='icon'  href='#random' onClick="portal.reload()"></a></p>`
   }
 
   //
@@ -46,7 +45,13 @@ function Portal (sites) {
   }
 
   this.start = function () {
-    this.el.innerHTML = window.location.hash && window.location.hash.length > 4 ? _redirect(this.next()) : _directory(this.sites)
+    if (window.location.hash && window.location.hash.length > 4) {
+      const site = this.next()
+      this.el.innerHTML = _redirect(site)
+      setTimeout(() => { window.location = site.url }, 3000)
+    } else {
+      this.el.innerHTML = _directory(this.sites)
+    }
   }
 
   this.reload = function () {
@@ -69,19 +74,18 @@ function Portal (sites) {
   }
 
   this.next = function (loc = this.locate()) {
-    return loc == this.sites.length - 1 ? this.sites[0] : this.sites[loc + 1]
+    return loc === this.sites.length - 1 ? this.sites[0] : this.sites[loc + 1]
   }
-
 }
 
 function toggleType (e) {
   e.preventDefault()
   const navLink = e.target
   const selectedType = navLink.dataset.type
-  document.querySelector(`nav a.current`).classList.remove('current')
+  document.querySelector('nav a.current').classList.remove('current')
   navLink.classList.add('current')
-  document.querySelectorAll(`main li`).forEach(el => el.style.display = 'block')
-  if(selectedType) {
-    document.querySelectorAll(`main li:not([data-type='${selectedType}'])`).forEach(el => el.style.display = 'none')
+  document.querySelectorAll('main li').forEach(el => { el.style.display = 'block' })
+  if (selectedType) {
+    document.querySelectorAll(`main li:not([data-type='${selectedType}'])`).forEach(el => { el.style.display = 'none' })
   }
 }


### PR DESCRIPTION
I was about to work on one of the other issues when I realized the way we were doing the redirect with the meta tag doesn't work on firefox since firefox blocks auto-refresh by default. I'm surprised we didn't catch that sooner (or maybe it was known?). Either way, this fixes that.

I also went through and cleaned up some residual stuff where we were calling `_reload('random')` all over the place, but that function doesn't take a parameter, so it wasn't doing anything. I also went through and did some other minor linting stuff.