### PR TITLE
Site Languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,25 @@ This [webring](https://wiki.xxiivv.com/webring) is an attempt to inspire artists
 ```
 
 1) Add the webring icon to your website html.
-2) Add your website information to the [sites.js](https://github.com/XXIIVV/webring/edit/master/scripts/sites.js) file. The `url` and `contact` keys are required, but you can also include `title`, `type`, `author`, `rss`, and `feed`. The title must be alphanumeric.
+2) Add your website information to the [sites.js](https://github.com/XXIIVV/webring/edit/master/scripts/sites.js) file. See all options below, and be mindful of what's required for each part of the webring.
 3) Submit a Pull Request with **the location of the webring icon** on your site. Pull requests with blank descriptions will be rejected.
 
 Alternatively, if you your website has a dark background, use `icon.white.svg`. If your website is complaining about *https*, go ahead and host the icon yourself.
+
+Only the `url`, `contact`, and `langs` keys are required to join the webring. Below you can find a list of all the available keys for the various areas of the webring.
+```javascript
+  {
+    author: <string used in the Hallway REQUIRED FOR HALLWAY>',
+    contact: <string used to contact if necessary REQUIRED FOR ALL>,
+    feed: <string url used Hallway REQUIRED FOR HALLWAY>,
+    langs: <array of iso language codes represented languages in your site ex. ['en'] REQUIRED FOR ALL>,
+    rss: <string url for rss feed>,
+    title: <string (must be alphanumeric) used for the Portal>,
+    type: <string used for the Portal>,
+    url: <string url used for Portal REQUIRED FOR ALL>,
+    wiki: <string url used for the Wiki REQUIRED FOR WIKI>
+  }
+```
 
 ### Webring criteria
 
@@ -34,7 +49,7 @@ Instead of linking to the directory, you can also link to the next link in the r
 
 [The Hallway](https://webring.xxiivv.com/hallway.html) is a decentralized forum using [twtxt](https://twtxt.readthedocs.io/en/stable/user/twtxtfile.html) feeds.
 
-To join, create a `.txt` file on your site, add its URL to [your webring entry](https://github.com/XXIIVV/Webring/blob/master/scripts/sites.js) as `feed:`, and fill in your desired name for `author:`. The content of the file should be a dateISO string, a tab(or 3 spaces) and a message:
+To join, create a `.txt` file on your site, add its URL to [your webring entry](https://github.com/XXIIVV/Webring/blob/master/scripts/sites.js) as `feed`, and fill in your desired name in the `author` key. The content of the file should be a dateISO string, a tab(or 3 spaces) and a message:
 
 ```
 2016-02-04T13:30:00+01:00   You can really go crazy here! ┐(ﾟ∀ﾟ)┌
@@ -49,7 +64,7 @@ You don't need to allow all origins nor allow any other methods rather than GET,
 
 [The Wiki](https://webring.xxiivv.com/wiki.html) is a decentralized encyclopedia using [ndtl](https://wiki.xxiivv.com/Indental) feeds.
 
-To join, create a `.ndtl` file on your site, and add its URL to [your webring entry](https://github.com/XXIIVV/Webring/blob/master/scripts/sites.js) as `wiki:`.
+To join, create a `.ndtl` file on your site, and add its URL to [your webring entry](https://github.com/XXIIVV/Webring/blob/master/scripts/sites.js) using the `wiki` key.
 
 ## Webring CLI
 

--- a/links/main.css
+++ b/links/main.css
@@ -16,7 +16,7 @@ body #portal #icon { display: block; width: 30px; height: 30px; background-image
 body #portal ul { columns:1;  }
 body #portal ul li { display:block; padding-left:5px; text-overflow: ellipsis; text-transform: lowercase;}
 body #portal ul li:before { content: attr(id) ")"; }
-body #portal ul li[data-type]::after { content:"<" attr(data-type) ">"; color:#555; }
+body #portal ul li::after { content:"<" attr(data-type) attr(data-lang) ">"; color:#555; }
 body #portal ul li a { line-height: 20px; padding:0px 5px; text-decoration: none;}
 body #portal ul li a:visited { color:#ccc; text-decoration: none;}
 body #portal a:active,
@@ -25,7 +25,8 @@ body #portal a:hover { text-decoration: underline; }
 
 body #portal nav { display: flex; flex-direction: row; margin-bottom: 15px }
 body #portal nav a { margin: 0 5px; color: gray }
-body #portal nav a.current { color: white }
+body #portal nav a.currentType,
+body #portal nav a.currentLang { color: white }
 
 body aside { min-width: 200px; padding: 0 15px; line-height: 16px; display: none; }
 body aside ul { margin-bottom: 15px; }

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -13,8 +13,7 @@ function Portal (sites) {
   function _directory (sites) {
     const siteTypesArray = [...new Set(sites.map(site => site.type).filter(Boolean))]
     const siteLangsArray = [...new Set(sites
-      .map(site => site.langs)
-      .reduce((flattened, langs) => flattened.concat(langs), [])
+      .reduce((flattened, site) => flattened.concat(site.langs), [])
       .sort())]
 
     const siteTypes = siteTypesArray.reduce((output, siteType) =>
@@ -39,8 +38,7 @@ function Portal (sites) {
   }
 
   function _lang (site) {
-    const langs = site.langs.reduce((langs, lang) => `${langs} ${lang}`, '')
-    return `data-lang="${langs.trim()}"`
+    return `data-lang="${site.langs.join(' ').trim()}"`
   }
 
   function _redirectView (site) {
@@ -73,8 +71,7 @@ function Portal (sites) {
   }
 
   this.sitesMatchingLangs = this.sites
-    .filter(site => site.langs)
-    .filter(site => site.langs.some(lang => navigator.languages.includes(lang)))
+    .filter(site => site.langs && site.langs.some(lang => navigator.languages.includes(lang)))
 
   this.next = function () {
     const hash = window.location.hash.replace('#', '').trim()

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -7,22 +7,27 @@ function Portal (sites) {
 
   // Templates
 
-  function _readme () {
-    return '<p class="readme">This webring is an attempt to inspire artists & developers to build their own website and share traffic among each other. The ring welcomes personalized websites such as <b>diaries, wikis & portfolios</b>.</p><p>To add yourself to the ring, submit a <a href="https://github.com/XXIIVV/webring/edit/master/scripts/sites.js" target="_blank">Pull Request</a>.<br />If you found a broken link, please <a href="https://github.com/XXIIVV/webring/issues/new" target="_blank">report it</a>.</p>'
-  }
-
-  function _buttons () {
-    return '<p class="buttons"><a href="#random" onClick="portal.reload()">Random</a> | <a href="https://github.com/XXIIVV/webring">Information</a> <a id="icon" href="#random" onClick="portal.reload()"></a> | <a href="hallway.html">The Hallway</a> | <a href="wiki.html">The Wiki</a> | <a id="opml">OPML</a></p>'
-  }
+  const _readme = '<p class="readme">This webring is an attempt to inspire artists & developers to build their own website and share traffic among each other. The ring welcomes personalized websites such as <b>diaries, wikis & portfolios</b>.</p><p>To add yourself to the ring, submit a <a href="https://github.com/XXIIVV/webring/edit/master/scripts/sites.js" target="_blank">Pull Request</a>.<br />If you found a broken link, please <a href="https://github.com/XXIIVV/webring/issues/new" target="_blank">report it</a>.</p>'
+  const _buttons = '<p class="buttons"><a href="#random" onClick="portal.reload()">Random</a> | <a href="https://github.com/XXIIVV/webring">Information</a> <a id="icon" href="#random" onClick="portal.reload()"></a> | <a href="hallway.html">The Hallway</a> | <a href="wiki.html">The Wiki</a> | <a id="opml">OPML</a></p>'
 
   function _directory (sites) {
     const siteTypesArray = [...new Set(sites.map(site => site.type).filter(Boolean))]
+    const siteLangsArray = [...new Set(sites
+      .map(site => site.langs)
+      .reduce((flattened, langs) => flattened.concat(langs), [])
+      .sort())]
+
     const siteTypes = siteTypesArray.reduce((output, siteType) =>
-      `${output}<a data-type="${siteType}" href="#" onclick="toggleType(event)">&lt;${siteType}&gt;</a>`,
-      '<a class="current" href="#" onclick="toggleType(event)">&lt;all&gt;</a>')
+      `${output}<a data-type="${siteType}" href="#" onclick="filterSites(event)">&lt;${siteType}&gt;</a>`,
+      '<a class="currentType" data-type="all" href="#" onclick="filterSites(event)">&lt;all&gt;</a>')
+
+    const siteLangs = siteLangsArray.reduce((output, siteLang) =>
+      `${output}<a data-lang="${siteLang}" href="#" onclick="filterSites(event)">&lt;${siteLang}&gt;</a>`,
+      '<a class="currentLang" data-lang="all" href="#" onclick="filterSites(event)">&lt;all&gt;</a>')
+
     const listItems = sites.reduce((acc, site, id) =>
-      `${acc}<li ${_type(site)} id='${id}'><a href='${site.url}'>${_name(site)}</a></li>`, '')
-    return `<nav>${siteTypes}</nav><main><ul>${listItems}</ul></main><footer>${_readme()}${_buttons()}</footer>`
+      `${acc}<li ${_type(site)} ${_lang(site)} id='${id}'><a href='${site.url}'>${_name(site)}</a></li>`, '')
+    return `<nav>${siteTypes}</nav><nav>${siteLangs}</nav><main><ul>${listItems}</ul></main><footer>${_readme}${_buttons}</footer>`
   }
 
   function _name (site) {
@@ -30,10 +35,15 @@ function Portal (sites) {
   }
 
   function _type (site) {
-    return site.type ? `data-type="${site.type}"` : ''
+    return site.type ? `data-type="${site.type} "` : ''
   }
 
-  function _redirect (site) {
+  function _lang (site) {
+    const langs = site.langs.reduce((langs, lang) => `${langs} ${lang}`, '')
+    return `data-lang="${langs.trim()}"`
+  }
+
+  function _redirectView (site) {
     return `<main><p>Redirecting to <a href="${site.url}">${site.url}</a></p></main>
       <footer><p class='buttons'><a href='#' onClick="portal.reload('')">Directory</a> | <a href='#${site.url}' onClick="portal.reload()">Skip</a> | <a href='#random' onClick="portal.reload()">Random</a> | <a href='https://github.com/XXIIVV/webring'>Information</a> <a id='icon'  href='#random' onClick="portal.reload()"></a></p>`
   }
@@ -47,7 +57,7 @@ function Portal (sites) {
   this.start = function () {
     if (window.location.hash && window.location.hash.length > 4) {
       const site = this.next()
-      this.el.innerHTML = _redirect(site)
+      this.el.innerHTML = _redirectView(site)
       setTimeout(() => { window.location = site.url }, 3000)
     } else {
       this.el.innerHTML = _directory(this.sites)
@@ -62,30 +72,48 @@ function Portal (sites) {
     setTimeout(() => { window.location.href = target }, 3000)
   }
 
-  this.locate = function () {
+  this.sitesMatchingLangs = this.sites
+    .filter(site => site.langs)
+    .filter(site => site.langs.some(lang => navigator.languages.includes(lang)))
+
+  this.next = function () {
     const hash = window.location.hash.replace('#', '').trim()
 
     if (hash === 'random') {
-      return Math.floor(Math.random() * this.sites.length)
+      return this.sitesMatchingLangs[Math.floor(Math.random() * this.sitesMatchingLangs.length)]
     } else {
-      const id = sites.findIndex(site => site.url.indexOf(hash) > -1)
-      return id > -1 ? parseInt(id) : -1
+      return sites.find(site => site.url.includes(hash))
+        ? sites.find(site => site.url.includes(hash))
+        : this.sitesMatchingLangs[Math.floor(Math.random() * this.sitesMatchingLangs.length)]
     }
-  }
-
-  this.next = function (loc = this.locate()) {
-    return loc === this.sites.length - 1 ? this.sites[0] : this.sites[loc + 1]
   }
 }
 
-function toggleType (e) {
+function filterSites (e) {
   e.preventDefault()
   const navLink = e.target
-  const selectedType = navLink.dataset.type
-  document.querySelector('nav a.current').classList.remove('current')
-  navLink.classList.add('current')
-  document.querySelectorAll('main li').forEach(el => { el.style.display = 'block' })
-  if (selectedType) {
-    document.querySelectorAll(`main li:not([data-type='${selectedType}'])`).forEach(el => { el.style.display = 'none' })
-  }
+  const currentFilter = navLink.dataset.lang ? 'Lang' : 'Type'
+
+  document.querySelector(`nav a.current${currentFilter}`).classList.remove(`current${currentFilter}`)
+  navLink.classList.add(`current${currentFilter}`)
+
+  const typeFilter = document.querySelector('nav a.currentType').dataset.type
+  const langFilter = document.querySelector('nav a.currentLang').dataset.lang
+
+  const sites = document.querySelectorAll('main li')
+  sites.forEach(el => { el.style.display = 'block' })
+
+  sites.forEach(el => {
+    if (typeFilter !== 'all') {
+      if (el.dataset.type) {
+        if (el.dataset.type.trim() !== typeFilter) el.style.display = 'none'
+      } else {
+        el.style.display = 'none'
+      }
+    }
+
+    if (langFilter !== 'all') {
+      if (!el.dataset.lang.includes(langFilter)) el.style.display = 'none'
+    }
+  })
 }

--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -5,646 +5,749 @@
 
 const sites = [
   {
-    url: 'https://wiki.xxiivv.com',
-    title: 'xxiivv',
-    type: 'wiki',
     author: 'neauoire',
     contact: 'aliceffekt@gmail.com',
-    rss: 'https://wiki.xxiivv.com/links/rss.xml',
     feed: 'https://wiki.xxiivv.com/twtxt.txt',
+    langs: ['en'],
+    rss: 'https://wiki.xxiivv.com/links/rss.xml',
+    title: 'xxiivv',
+    type: 'wiki',
+    url: 'https://wiki.xxiivv.com',
     wiki: 'https://wiki.xxiivv.com/scripts/database/glossary.ndtl'
   },
 
   {
+    langs: ['en'],
     url: 'http://estevancarlos.com'
   },
 
   {
-    url: 'https://electro.pizza',
+    author: 'rho',
+    feed: 'https://electro.pizza/twtxt.txt',
+    langs: ['en'],
     title: 'electro pizza',
     type: 'blog',
-    author: 'rho',
     rss: 'https://electro.pizza/feed.xml',
-    feed: 'https://electro.pizza/twtxt.txt'
+    url: 'https://electro.pizza'
   },
 
   {
-    url: 'https://avanier.now.sh',
-    title: 'Arachne',
-    type: 'wiki',
     author: 'joshavanier',
     contact: 'joshavanier@protonmail.com',
-    feed: 'https://avanier.now.sh/tw.txt'
+    feed: 'https://avanier.now.sh/tw.txt',
+    langs: ['en'],
+    title: 'Arachne',
+    type: 'wiki',
+    url: 'https://avanier.now.sh'
   },
 
   {
-    url: 'http://kaemura.com',
-    title: 'kaemura.com',
-    type: 'blog',
     author: 'kaemura',
     contact: 'chimera1190@gmail.com',
-    feed: 'https://kaemura.com/twttxt.txt'
+    feed: 'https://kaemura.com/twttxt.txt',
+    langs: ['en'],
+    title: 'kaemura.com',
+    type: 'blog',
+    url: 'http://kaemura.com'
   },
 
   {
-    url: 'https://liamcooke.com',
-    title: 'liamcooke.com',
     author: 'slisne',
     contact: '@slisne@merveilles.town',
+    feed: 'https://liamcooke.com/merveilles/tw.txt',
+    langs: ['en'],
+    title: 'liamcooke.com',
     rss: 'https://liamcooke.com/feed.xml',
-    wiki: 'https://liamcooke.com/merveilles/wiki.ndtl',
-    feed: 'https://liamcooke.com/merveilles/tw.txt'
+    url: 'https://liamcooke.com',
+    wiki: 'https://liamcooke.com/merveilles/wiki.ndtl'
   },
 
   {
-    url: 'https://electricgecko.de',
-    title: 'electricgecko',
-    type: 'blog',
     author: 'electricgecko',
     contact: 'desk@electricgecko.de',
-    rss: 'https://electricgecko.de/feed'
+    langs: ['de', 'en'],
+    title: 'electricgecko',
+    rss: 'https://electricgecko.de/feed',
+    type: 'blog',
+    url: 'https://electricgecko.de'
   },
 
   {
+    langs: ['en'],
     url: 'https://wichniow.ski'
   },
 
   {
+    langs: ['en'],
     url: 'https://hraew.autophagy.io'
   },
 
   {
+    langs: ['en'],
     url: 'http://evenunto.net'
   },
 
   {
+    langs: ['en'],
     url: 'https://anxl.faith'
   },
 
   {
-    url: 'https://xvw.github.io',
-    title: 'xvw.github.io',
-    type: 'blog',
     author: 'xvw',
     contact: 'xaviervdw@gmail.com',
-    rss: 'https://xvw.github.io/atom.xml'
+    langs: ['fr'],
+    rss: 'https://xvw.github.io/atom.xml',
+    title: 'xvw.github.io',
+    type: 'blog',
+    url: 'https://xvw.github.io'
   },
 
   {
+    langs: ['en', 'el'],
     url: 'https://heracl.es'
   },
 
   {
+    langs: ['en'],
     url: 'http://luminghao.com'
   },
 
   {
+    langs: ['en'],
     url: 'https://turelio.github.io'
   },
 
   {
-    url: 'https://shards.lectronice.com',
-    title: 'shards',
-    type: 'blog',
     author: 'lectronice',
     contact: 'i.love.spam@lectronice.com',
-    feed: 'https://lectronice.com/hallway/twtxt.txt'
+    feed: 'https://lectronice.com/hallway/twtxt.txt',
+    langs: ['en'],
+    title: 'shards',
+    type: 'blog',
+    url: 'https://shards.lectronice.com'
   },
 
   {
+    langs: ['en'],
     url: 'https://craze.co.uk'
   },
 
   {
+    langs: ['en'],
     url: 'https://shaneckel.com'
   },
 
   {
-    url: 'https://cblgh.org',
-    title: 'cblgh.org',
     author: 'cblgh',
     contact: 'cabal://cblgh.org',
-    feed: 'https://cblgh.org/twtxt.txt'
+    feed: 'https://cblgh.org/twtxt.txt',
+    langs: ['en'],
+    title: 'cblgh.org',
+    url: 'https://cblgh.org'
   },
 
   {
-    url: 'https://ellugar.co',
-    title: 'ellugar',
-    type: 'wiki',
     author: 'afk',
     contact: 'afk@ellugar.co',
-    rss: 'http://feeds.ellugar.co/ellugar-logs'
+    langs: ['en'],
+    rss: 'http://feeds.ellugar.co/ellugar-logs',
+    title: 'ellugar',
+    type: 'wiki',
+    url: 'https://ellugar.co'
   },
 
   {
-    url: 'http://chigby.org',
+    author: 'Cameron Higby-Naquin',
+    contact: 'me@chigby.org',
+    langs: ['en'],
     title: 'chigby.org',
     type: 'portfolio',
-    contact: 'me@chigby.org',
-    author: 'Cameron Higby-Naquin'
+    url: 'http://chigby.org'
   },
 
   {
+    langs: ['en'],
     url: 'https://longest.voyage'
   },
 
   {
+    langs: ['en'],
     url: 'https://palomakop.tv'
   },
 
   {
+    langs: ['en'],
     url: 'https://v-os.ca'
   },
 
   {
+    langs: ['en'],
     url: 'https://jmandel.xyz'
   },
 
   {
+    langs: ['en'],
     url: 'https://systems.ws'
   },
 
   {
-    url: 'https://2d4.dev',
-    title: '2d4.dev',
     author: 'jda0',
     contact: 'hi@2d4.dev',
     feed: 'https://2d4.dev/tw.txt',
+    langs: ['en'],
+    title: '2d4.dev',
+    url: 'https://2d4.dev',
     wiki: 'https://2d4.dev/wiki.ndtl'
   },
 
   {
+    langs: ['en'],
     url: 'https://nathanwentworth.co'
   },
 
   {
+    langs: ['en'],
     url: 'https://uonai.space'
   },
 
   {
+    langs: ['en'],
     url: 'http://controls.ee'
   },
 
   {
+    langs: ['en'],
     url: 'https://wasin.io'
   },
 
   {
+    langs: ['en'],
     url: 'https://inns.studio'
   },
 
   {
+    langs: ['en'],
     url: 'http://kokorobot.ca'
   },
 
   {
-    url: 'https://ameyama.com',
-    title: 'ameyama',
-    type: 'blog',
     author: 'jrc03c',
     contact: 'josh@ameyama.com',
+    langs: ['en'],
+    title: 'ameyama',
+    type: 'blog',
     rss: 'https://ameyama.com/blog/rss.xml',
+    url: 'https://ameyama.com',
     wiki: 'https://ameyama.com/data/wiki.ndtl'
   },
 
   {
-    url: 'https://wake.st',
-    title: 'wake.st',
     author: 'wakest',
     contact: '@liaizon@wake.st',
-    feed: 'https://wake.st/twtxt.txt'
+    feed: 'https://wake.st/twtxt.txt',
+    langs: ['en'],
+    title: 'wake.st',
+    url: 'https://wake.st'
   },
 
   {
+    langs: ['en'],
     url: 'https://xarene.la'
   },
 
   {
+    langs: ['en'],
     url: 'https://alex.zyzhang.me'
   },
 
   {
+    langs: ['en'],
     url: 'http://bildwissenschaft.vortok.info'
   },
 
   {
+    langs: ['en'],
     url: 'https://jakofranko.github.com'
   },
 
   {
+    langs: ['en'],
     url: 'https://aeriform.io'
   },
 
   {
+    langs: ['en', 'de'],
     url: 'http://blog.lucasdidthis.com'
   },
 
   {
-    url: 'http://npisanti.com',
-    title: 'npisanti.com',
     author: 'npisanti',
     contact: 'nicola@npisanti.com',
-    rss: 'http://npisanti.com/journal/rss.xml'
+    langs: ['en'],
+    rss: 'http://npisanti.com/journal/rss.xml',
+    title: 'npisanti.com',
+    url: 'http://npisanti.com'
   },
 
   {
+    langs: ['en'],
     url: 'https://underscorediscovery.ca'
   },
 
   {
-    url: 'https://drisc.io',
-    title: 'drisc.io',
-    type: 'wiki',
     author: 'drisc',
     contact: 'cory@drisc.io',
-    feed: 'https://drisc.io/hallway/twtxt.txt'
+    feed: 'https://drisc.io/hallway/twtxt.txt',
+    langs: ['en'],
+    title: 'drisc.io',
+    type: 'wiki',
+    url: 'https://drisc.io'
   },
 
   {
-    url: 'https://neufv.systems',
-    author: 'neufv'
+    author: 'neufv',
+    langs: ['en'],
+    url: 'https://neufv.systems'
   },
 
   {
+    langs: ['en'],
     url: 'https://ricky.codes'
   },
 
   {
-    url: 'https://maxdeviant.com',
+    author: 'Marshall Bowers',
+    contact: 'elliott.codes@gmail.com',
+    langs: ['en'],
     title: 'maxdeviant.com',
     type: 'hybrid',
-    author: 'Marshall Bowers',
-    contact: 'elliott.codes@gmail.com'
+    url: 'https://maxdeviant.com'
   },
 
   {
+    langs: ['en'],
     url: 'https://tynandebold.com'
   },
 
   {
+    langs: ['en'],
     url: 'http://gytis.co'
   },
 
   {
+    langs: ['en'],
     url: 'https://nomand.co'
   },
 
   {
+    langs: ['en'],
     url: 'http://memoriata.com'
   },
 
   {
+    langs: ['en'],
     url: 'https://mmm.s-ol.nu'
   },
 
   {
+    langs: ['en'],
     url: 'https://chad.is'
   },
 
   {
+    langs: ['en'],
     url: 'https://smidgeo.com/bots'
   },
 
   {
+    langs: ['en', 'ru'],
     url: 'https://iko.soy'
   },
 
   {
+    langs: ['en'],
     url: 'http://atelieroilandsugar.com'
   },
 
   {
+    langs: ['en'],
     url: 'https://magoz.is'
   },
 
   {
-    url: 'https://szymonkaliski.com',
     author: 'Szymon Kaliski',
+    langs: ['en'],
+    rss: 'https://szymonkaliski.com/feed.xml',
     type: 'hybrid',
-    rss: 'https://szymonkaliski.com/feed.xml'
+    url: 'https://szymonkaliski.com'
   },
 
   {
-    url: 'https://phse.net',
+    author: 'setphen',
+    feed: 'https://phse.net/twtxt/merv.txt',
+    langs: ['en'],
+    rss: 'https://phse.net/post/index.xml',
     title: 'phse.net',
     type: 'blog',
-    author: 'setphen',
-    rss: 'https://phse.net/post/index.xml',
-    feed: 'https://phse.net/twtxt/merv.txt'
+    url: 'https://phse.net'
   },
 
   {
+    langs: ['en'],
     url: 'https://rosano.ca'
   },
 
   {
+    langs: ['en'],
     url: 'https://soyboysky.github.io'
   },
 
   {
+    langs: ['en'],
     url: 'https://gndclouds.cc'
   },
 
   {
+    langs: ['en', 'fr'],
     url: 'https://xuv.be'
   },
 
   {
+    langs: ['en', 'zh'],
     url: 'https://dsdshcym.github.io'
   },
 
   {
-    url: 'https://wiki.chronica.xyz',
-    title: 'chronica',
-    type: 'wiki',
     author: 'ckipp',
     contact: 'ckipp@pm.me',
     feed: 'https://chronica.xyz/hallway.txt',
+    langs: ['en'],
+    title: 'chronica',
+    type: 'wiki',
+    url: 'https://wiki.chronica.xyz',
     wiki: 'https://chronica.xyz/glossary.ndtl'
   },
 
   {
+    langs: ['en'],
     url: 'https://boffosocko.com'
   },
 
   {
-    url: 'https://hex22.org',
-    title: 'hex22',
     author: 'kodedninja',
     contact: 'karamanhunor@pm.me',
-    feed: 'https://t.seed.hex22.org/twtxt.txt'
+    feed: 'https://t.seed.hex22.org/twtxt.txt',
+    langs: ['en'],
+    title: 'hex22',
+    url: 'https://hex22.org'
   },
 
   {
+    langs: ['en'],
     url: 'https://patrikarvidsson.com'
   },
 
   {
+    langs: ['en'],
     url: 'https://sophieleetmaa.com'
   },
 
   {
+    langs: ['en'],
     url: 'https://xinniw.github.io'
   },
 
   {
-    url: 'https://mboxed.github.io/sodatsu',
-    title: 'sodatsu',
-    type: 'wiki',
     author: 'm',
     contact: 'mboxxed@gmail.com',
-    feed: 'https://mboxed.github.io/sodatsu/tw.txt'
+    feed: 'https://mboxed.github.io/sodatsu/tw.txt',
+    langs: ['en'],
+    title: 'sodatsu',
+    type: 'wiki',
+    url: 'https://mboxed.github.io/sodatsu'
   },
 
   {
+    langs: ['en'],
     url: 'https://letters.vexingworkshop.com'
   },
 
   {
-    url: 'https://tom.org.nz',
-    title: 'Tom Hackshaw',
-    type: 'portfolio',
     author: 'tomupom',
     contact: 'tom@tomhackshaw.com',
+    langs: ['en'],
+    title: 'Tom Hackshaw',
+    type: 'portfolio',
+    url: 'https://tom.org.nz',
     wiki: 'https://a.tom.org.nz/glossary.ndtl'
   },
 
   {
+    langs: ['en'],
     url: 'https://teknari.com'
   },
 
   {
-    url: 'https://colectivo-de-livecoders.gitlab.io',
+    author: 'clic',
+    contact: 'https://t.me/clic_laplata',
+    langs: ['es'],
     title: 'Colectivo de Livecoders',
     type: 'blog',
-    author: 'clic',
-    contact: 'https://t.me/clic_laplata'
+    url: 'https://colectivo-de-livecoders.gitlab.io'
   },
 
   {
-    url: 'https://www.madewithtea.com',
+    langs: ['es'],
     title: 'madewithtea.com',
-    type: 'blog'
+    type: 'blog',
+    url: 'https://www.madewithtea.com'
   },
 
   {
-    url: 'https://amorris.ca',
-    title: 'amorris',
     author: 'amorris',
-    type: 'blog',
     feed: 'https://feed.amorris.ca/hallway.txt',
+    langs: ['en'],
+    title: 'amorris',
+    type: 'blog',
+    url: 'https://amorris.ca',
     wiki: 'https://wiki.amorris.ca/glossary.ndtl'
   },
 
   {
-    url: 'http://www.miha-co.ca',
+    langs: ['en'],
     title: 'miha-co',
-    type: 'portfolio'
+    type: 'portfolio',
+    url: 'http://www.miha-co.ca'
   },
 
   {
-    url: 'https://buzzert.net',
-    title: 'buzzert.net',
     author: 'buzzert',
-    type: 'blog'
+    langs: ['en'],
+    title: 'buzzert.net',
+    type: 'blog',
+    url: 'https://buzzert.net'
   },
 
   {
-    url: 'https://notes.stuartpb.com/',
-    title: 'notes.stuartpb.com',
-    type: 'wiki',
     author: 'stuartpb',
     contact: 's@stuartpb.com',
-    feed: 'https://twtxt.stuartpb.com/xxiivv.txt'
+    feed: 'https://twtxt.stuartpb.com/xxiivv.txt',
+    langs: ['en'],
+    title: 'notes.stuartpb.com',
+    type: 'wiki',
+    url: 'https://notes.stuartpb.com/'
   },
 
   {
-    url: 'https://xxiii.co',
-    title: 'xxiii',
-    type: 'portfolio',
     author: 'serocell',
     contact: 'psignal@s900.net',
+    feed: 'https://xxiii.co/twtxt.txt',
+    langs: ['en'],
     rss: 'https://serocell.com/feeds/serocell.xml',
-    feed: 'https://xxiii.co/twtxt.txt'
+    title: 'xxiii',
+    type: 'portfolio',
+    url: 'https://xxiii.co'
   },
 
   {
-    url: 'https://kor.nz',
-    title: 'kor',
-    type: 'wiki',
     author: 'kormyen',
     contact: 'h@kor.nz',
     feed: 'https://kor.nz/twtxt.txt',
+    langs: ['en'],
+    title: 'kor',
+    type: 'wiki',
+    url: 'https://kor.nz',
     wiki: 'https://kor.nz/db/glossary.ndtl'
   },
 
   {
-    url: 'https://lublin.se',
     author: 'quite',
     contact: 'quite@hack.org',
-    feed: 'https://lublin.se/twtxt.txt'
+    feed: 'https://lublin.se/twtxt.txt',
+    langs: ['en'],
+    url: 'https://lublin.se'
   },
 
   {
-    url: 'https://zanneth.com',
-    title: 'zanneth.com',
     author: 'zanneth',
+    contact: 'root@zanneth.com',
+    langs: ['en'],
+    title: 'zanneth.com',
     type: 'blog',
-    contact: 'root@zanneth.com'
+    url: 'https://zanneth.com'
   },
 
   {
-    url: 'https://eli.li',
-    title: 'eli.li',
     author: 'eli_oat',
-    type: 'blog',
     contact: 'hi@eli.li',
+    feed: 'https://txt.eli.li/twtxt/twtxt.txt',
+    langs: ['en'],
     rss: 'https://eli.li/feed.rss',
-    feed: 'https://txt.eli.li/twtxt/twtxt.txt'
-  },
-
-  {
-    url: 'https://gueorgui.net',
-    title: 'Gueorgui Tcherednitchenko',
-    author: 'gueorgui',
-    type: 'portfolio',
-    contact: 'hello@gueorgui.net'
-  },
-
-  {
-    url: 'https://www.gkbrk.com',
-    title: 'Leo',
-    author: 'Leo',
+    title: 'eli.li',
     type: 'blog',
-    contact: 'webring@gkbrk.com',
-    rss: 'https://www.gkbrk.com/feed.xml',
-    feed: 'https://www.gkbrk.com/twtxt.txt'
+    url: 'https://eli.li'
   },
 
   {
-    url: 'https://www.tatecarson.com',
+    author: 'gueorgui',
+    contact: 'hello@gueorgui.net',
+    langs: ['en'],
+    title: 'Gueorgui Tcherednitchenko',
+    type: 'portfolio',
+    url: 'https://gueorgui.net'
+  },
+
+  {
+    author: 'Leo',
+    contact: 'webring@gkbrk.com',
+    feed: 'https://www.gkbrk.com/twtxt.txt',
+    langs: ['en'],
+    rss: 'https://www.gkbrk.com/feed.xml',
+    title: 'Leo',
+    type: 'blog',
+    url: 'https://www.gkbrk.com'
+  },
+
+  {
+    author: 'Tate Carson',
+    contact: 'tatecarson@gmail.com',
+    langs: ['en'],
     title: 'Tate Carson',
     type: 'portfolio',
-    author: 'Tate Carson',
-    contact: 'tatecarson@gmail.com'
+    url: 'https://www.tatecarson.com'
   },
 
   {
-    url: 'https://azlen.me',
-    title: 'azlen.me',
     author: 'azlen',
-    type: 'wiki',
     contact: 'webring@azlen.me',
     feed: 'https://azlen.me/twtxt.txt',
+    langs: ['en'],
+    title: 'azlen.me',
+    type: 'wiki',
+    url: 'https://azlen.me',
     wiki: 'https://azlen.me/glossary.ndtl'
   },
 
   {
-    url: 'https://opinionatedguide.github.io/',
-    title: 'OpGuides',
     author: 'vega',
     contact: 'vegac@protonmail.com',
-    feed: 'https://opinionatedguide.github.io/twtxt.txt'
+    feed: 'https://opinionatedguide.github.io/twtxt.txt',
+    langs: ['en'],
+    title: 'OpGuides',
+    url: 'https://opinionatedguide.github.io/'
   },
 
   {
-    url: 'https://chrismaughan.com/',
-    title: 'CMaughan',
     author: 'cmaughan',
     contact: 'mornymorny@gmail.com',
-    feed: 'https://chrismaughan.com/twtxt.txt'
+    feed: 'https://chrismaughan.com/twtxt.txt',
+    langs: ['en'],
+    title: 'CMaughan',
+    url: 'https://chrismaughan.com/'
   },
 
   {
-    url: 'https://oddworlds.org/',
-    title: 'oddworlds soliloquy',
-    type: 'blog',
     author: 'RaelZero',
-    contact: 'gaz.gong@gmail.com'
+    contact: 'gaz.gong@gmail.com',
+    title: 'oddworlds soliloquy',
+    langs: ['en', 'es'],
+    type: 'blog',
+    url: 'https://oddworlds.org/'
   },
 
   {
-    url: 'https://fundor333.com/',
-    title: 'Fundor333',
-    type: 'blog',
     author: 'Fundor 333',
     contact: 'blog@fundor333.com',
-    feed: 'https://fundor333.com/twtxt.txt'
+    feed: 'https://fundor333.com/twtxt.txt',
+    langs: ['en'],
+    title: 'Fundor333',
+    type: 'blog',
+    url: 'https://fundor333.com/'
   },
 
   {
-    url: 'https://cass.si/',
-    contact: 'm@cass.si'
+    contact: 'm@cass.si',
+    langs: ['en'],
+    url: 'https://cass.si/'
   },
 
   {
-    url: 'https://dotcomboom.somnolescent.net/',
-    title: 'dotcomboom.somnolescent.net',
     author: 'dcb',
     contact: 'dotcomboom@somnolescent.net',
-    feed: 'https://dotcomboom.somnolescent.net/twtxt.txt'
+    feed: 'https://dotcomboom.somnolescent.net/twtxt.txt',
+    langs: ['en'],
+    title: 'dotcomboom.somnolescent.net',
+    url: 'https://dotcomboom.somnolescent.net/'
   },
 
   {
-    url: 'https://cadmican.neocities.org/',
-    title: 'cadmican',
+    author: 'Nihiltarier',
     contact: 'arachi@airmail.cc',
-    author: 'Nihiltarier'
+    langs: ['en'],
+    title: 'cadmican',
+    url: 'https://cadmican.neocities.org/'
   },
 
   {
-    url: 'https://jskjott.com',
-    title: 'jskjott',
+    author: 'Jonathan Skjøtt',
     contact: 'jonathan@jskjott.com',
-    author: 'Jonathan Skjøtt'
+    langs: ['en'],
+    title: 'jskjott',
+    url: 'https://jskjott.com'
   },
 
   {
-    url: 'https://sixey.es/',
-    title: 'sixey.es',
-    contact: 'elmusho@gmail.com',
     author: 'sixeyes',
-    type: 'portfolio'
+    contact: 'elmusho@gmail.com',
+    langs: ['en'],
+    title: 'sixey.es',
+    type: 'portfolio',
+    url: 'https://sixey.es/'
   },
 
   {
-    url: 'https://tilde.town/~dustin/',
-    title: '0xdstn',
-    contact: '0xdstn@protonmail.com',
     author: '0xdstn',
-    type: 'wiki'
-  },
-  
-   {
-    url: 'https://jameschip.io/',
-    title: 'James Chip',
-    contact: 'henderson.j@protonmail.com',
-    author: 'James',
-    rss: 'https://jameschip.io/index.xml'   
+    contact: '0xdstn@protonmail.com',
+    langs: ['en'],
+    title: '0xdstn',
+    type: 'wiki',
+    url: 'https://tilde.town/~dustin/'
   },
 
-  { 
-    url: 'https://dym.sh',
-    type: 'hybrid',
+  {
+    author: 'James',
+    contact: 'henderson.j@protonmail.com',
+    langs: ['en'],
+    rss: 'https://jameschip.io/index.xml',
+    title: 'James Chip',
+    url: 'https://jameschip.io/'
+  },
+
+  {
     author: 'DYM',
     contact: 're@dym.sh',
-    rss: 'https://dym.sh/rss.xml' 
+    langs: ['en', 'ru'],
+    rss: 'https://dym.sh/rss.xml',
+    type: 'hybrid',
+    url: 'https://dym.sh'
   },
 
   { 
-    url: 'https://patrick-is.cool/',
     author: 'Patrick Monaghan',
     contact: '0x5f.manpat@gmail.com',
-    type: 'portfolio'
+    langs: ['en'],
+    type: 'portfolio',
+    url: 'https://patrick-is.cool/'
   },
   
   {
-    url: 'https://icyphox.sh',
-    type: 'hybrid',
     author: 'icyphox',
     contact: 'x@icyphox.sh',
+    feed: 'https://icyphox.sh/twtxt.txt',
+    langs: ['en'],
     rss: 'https://icyphox.sh/blog/feed.xml',
-    feed: 'https://icyphox.sh/twtxt.txt'
+    type: 'hybrid',
+    url: 'https://icyphox.sh'
   }
 
 ]


### PR DESCRIPTION
closes #282 

This was pretty fun to implement, and I think it will work pretty well. This implements 2 different things:

1) When a user hits `#random` or is directed there, the langs that they have used are grabbed from [navigator.languages](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages) which will return an array of their browsers preferred languages. Then if a site contains a language code that matches any of their preferred languages, it will be a possibility. If not, it will be filtered out. However, they can still see that site if they are looking at the listing of course.

2) Regarding the listing, you can now also see the site langs next to the site type. I've included a screenshot below to illustrate. I just went through all the sites and did my best to include the language represented there. I only included a second language if there was at least like a full blog entry or something in that language.


<img width="845" alt="Screenshot 2019-09-14 at 20 41 38" src="https://user-images.githubusercontent.com/13974112/64912460-16a7ab80-d730-11e9-9dd3-d769156b7d92.png">
