### PR TITLE
Update my Webring entry with my new site

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -103,8 +103,8 @@ const sites = [
   },
 
   {
-    url: 'https://log.lectronice.com',
-    title: 'lectrolog.',
+    url: 'https://shards.lectronice.com',
+    title: 'shards',
     type: 'blog',
     author: 'lectronice',
     contact: 'i.love.spam@lectronice.com',


### PR DESCRIPTION
Seems like I'm now using my Hallway modification as a real microblog, so it's time to drop my crappy old WP (Webring logo in the footer).