### PR TITLE
small fixes in readme and url trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Alternatively, if you your website has a dark background, use `icon.white.svg`. 
 Only the `url`, `contact`, and `langs` keys are required to join the webring. Below you can find a list of all the available keys for the various areas of the webring.
 ```javascript
   {
-    author: <string used in the Hallway REQUIRED FOR HALLWAY>',
+    author: <string used in the Hallway REQUIRED FOR HALLWAY>,
     contact: <string used to contact if necessary REQUIRED FOR ALL>,
     feed: <string url used Hallway REQUIRED FOR HALLWAY>,
     langs: <array of iso language codes represented languages in your site ex. ['en'] REQUIRED FOR ALL>,

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -30,7 +30,7 @@ function Portal (sites) {
   }
 
   function _name (site) {
-    return site.title || `${site.url.split('//')[1]}`
+    return site.title || `${site.url.split('//')[1].replace(/\/+$/,'')}`
   }
 
   function _type (site) {

--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -662,7 +662,7 @@ const sites = [
   {
     contact: 'm@cass.si',
     langs: ['en'],
-    url: 'https://cass.si/'
+    url: 'https://cass.si'
   },
 
   {
@@ -726,14 +726,14 @@ const sites = [
     url: 'https://dym.sh'
   },
 
-  { 
+  {
     author: 'Patrick Monaghan',
     contact: '0x5f.manpat@gmail.com',
     langs: ['en'],
     type: 'portfolio',
-    url: 'https://patrick-is.cool/'
+    url: 'https://patrick-is.cool'
   },
-  
+
   {
     author: 'icyphox',
     contact: 'x@icyphox.sh',


### PR DESCRIPTION
- unexpected single qoutation mark in readme
- remove final slashes from sites-entries w/o site-names (i think i saw a rule or smth related to that before, but it looks better now anyway)
- handle urls with final slashes from now on