### PR TITLE
add in styling to accommodate for more sites in the portal

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -10,8 +10,10 @@ body strong { font-weight: bold; }
 body .selected { background: white; color:black; }
 
 /* portal */
+body #portal { display: flex; flex-direction: column; }
+body #portal main { flex: 1 0 auto; }
 body #portal main,
-body #portal footer { max-width: 800px; }
+body #portal footer { max-width: 1080px; flex-shrink: 0 }
 body #portal #icon { display: block; width: 30px; height: 30px; background-image: url(../icon.white.svg); background-size: cover; background-repeat: no-repeat; position: absolute; bottom: 15px; right:15px; background-position: center; padding:0px }
 body #portal ul { columns:1;  }
 body #portal ul li { display:block; padding-left:5px; text-overflow: ellipsis; text-transform: lowercase;}
@@ -92,5 +94,9 @@ body #progress { color: #777; }
   body #hallway #footer { max-width: calc(100% - 300px); }
   body #wiki main { max-width: calc(100% - 230px); }
   body #wiki footer { margin-right: 225px; max-width: calc(100% - 300px); }
+}
+
+@media (min-width: 992px) {
+  body #portal ul { columns: 4;}
 }
 


### PR DESCRIPTION
<img width="1676" alt="Screenshot 2019-10-06 at 18 02 55" src="https://user-images.githubusercontent.com/13974112/66271894-99b9ae80-e863-11e9-8fd6-389bebc710e4.png">

We are getting to the number of sites that 3 columns aren't working the best as it's causing the screen to have to scroll a bit. This will allow for the sites to be able to keep growing and displaying nicely. Basically, just bump to 4 columns when the screen is wide enough. I also added in a sticky footer, since I think it looks nice.