### PR TITLE
Use non-hyphenated code when matching language

### DIFF
--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -71,8 +71,9 @@ function Portal (sites) {
     setTimeout(() => { window.location.href = target }, 3000)
   }
 
+  const simplifiedCodes = Array.from(new Set([].concat.apply([], navigator.languages.map(code => [code, code.split('-').shift()]))))
   this.sitesMatchingLangs = this.sites
-    .filter(site => site.langs && site.langs.some(lang => navigator.languages.includes(lang)))
+    .filter(site => site.langs && site.langs.some(lang => simplifiedCodes.includes(lang)))
 
   this.nextSiteIndex = (ceiling, index) => index === ceiling ? 0 : index + 1
   this.randomSite = this.sitesMatchingLangs[Math.floor(Math.random() * this.sitesMatchingLangs.length)]

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -71,9 +71,10 @@ function Portal (sites) {
     setTimeout(() => { window.location.href = target }, 3000)
   }
 
-  const simplifiedCodes = Array.from(new Set([].concat.apply([], navigator.languages.map(code => [code, code.split('-').shift()]))))
+  this.navLangs = [... new Set(navigator.languages.map(lang => lang.split('-').shift()))]
+
   this.sitesMatchingLangs = this.sites
-    .filter(site => site.langs && site.langs.some(lang => simplifiedCodes.includes(lang)))
+    .filter(site => site.langs && site.langs.some(lang => this.navLangs.includes(lang)))
 
   this.nextSiteIndex = (ceiling, index) => index === ceiling ? 0 : index + 1
   this.randomSite = this.sitesMatchingLangs[Math.floor(Math.random() * this.sitesMatchingLangs.length)]


### PR DESCRIPTION
This change fixes a bug where a hyphenated language code (e.g. `en-CA`) causes the script to crash because no site matches. Chrome passes the non-hyphenated form as well, but Safari does not.