### PR TITLE
Additional sanitization on channel and tag to prevent onclick injection

### DIFF
--- a/scripts/hallway.js
+++ b/scripts/hallway.js
@@ -171,8 +171,8 @@ function Hallway (sites) {
       const parts = line.replace('  ', '\t').split('\t')
       const date = parts[0].trim()
       const body = escapeHtml(parts[1].trim()).trim()
-      const channel = body.substr(0, 1) === '/' ? body.split(' ')[0].substr(1).toLowerCase() : body.substr(0, 1) === '@' ? 'veranda' : 'lobby'
-      const tags = (body.match(reTag) || []).map(a => a.substr(a.indexOf('#') + 1).toLowerCase())
+      const channel = body.substr(0, 1) === '/' ? cleanTags(body.split(' ')[0].substr(1).toLowerCase()) : body.substr(0, 1) === '@' ? 'veranda' : 'lobby'
+      const tags = (body.match(reTag) || []).map(a => cleanTags(a.substr(a.indexOf('#') + 1).toLowerCase()))
       const offset = new Date() - new Date(date)
       entries.push({ date, body, author, offset, channel, tags })
     }
@@ -213,6 +213,10 @@ function toggleVisibility (id) {
 
 function escapeHtml (unsafe) {
   return unsafe.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;')
+}
+
+function cleanTags (unsafe){
+  return unsafe.replace(/([^a-z0-9]+)/gi, '-')
 }
 
 function stripHash (hash) {


### PR DESCRIPTION
In the `aside` section, user supplied `val` is used directly in the `onclick` event attribute for channels, users and tags:

Although feed content is cleaned in `escapeHtml`, the page can still be manipulated by bad input since it's already inside `onclick`.

**Example**
`2020-01-20T20:20:20+02:00   /");alert("vs` as an entry in a twtxt file will display an message when the channel is clicked since:
`onclick='filter("${val}")'` is expanded to:
`onclick="filter(&quot;&quot;);alert(&quot;vs&quot;)"` and executes despite sanitization.

I fixed this by whitelisting only alphanumeric values separated by dashes for the channels and tags, in `cleanTags`.  This also limits changes to the message content, where people will legitimately use many weird characters, so the tags are sanitized but the content remains as the author intended.

Since there is no private data or accounts on hallway, this isn't much of a security issue.  However, it should be addressed since it is possible to deface the hallway or accidentally break functionality (unescaped comments, etc.)