### PR TITLE
Add CLiC GBA-CABA site

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -814,6 +814,14 @@ const sites = [
     url: 'https://aklsh.github.io',
     type: 'hybrid'
   },
+  
+  {
+    author: 'clic',
+    contact: 'https://t.me/clic_gbacaba',
+	  title: 'CLiC - Colectivo de Live Coders | nodo GBA - CABA',
+	  langs: ['es'],
+    url: 'https://clic-gba-caba.gitlab.io/'
+  },
 
   {
     author: 'hxii',

--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -818,8 +818,8 @@ const sites = [
   {
     author: 'clic',
     contact: 'https://t.me/clic_gbacaba',
-	  title: 'CLiC - Colectivo de Live Coders | nodo GBA - CABA',
-	  langs: ['es'],
+    title: 'CLiC - Colectivo de Live Coders | nodo GBA - CABA',
+    langs: ['es'],
     url: 'https://clic-gba-caba.gitlab.io/'
   },
 


### PR DESCRIPTION
The webring link is at the bottom of the page (https://clic-gba-caba.gitlab.io/), in the useful links section.