### PR TITLE
Update sites.js

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -847,6 +847,15 @@ const sites = [
     rss: 'https://xj9.io/rss.xml',
     url: 'https://xj9.io',
     wiki: 'https://xj9.io/.well-known/webring/wiki.ndtl'
+  },
+  
+  {
+    contact: 'joe.jenett@jenett.org',
+    langs: ['en'],
+    rss: 'https://simply.personal.jenett.org/feed',
+    title: 'jenett. simply. personal.',
+    type: 'blog',
+    url: 'https://simply.personal.jenett.org',
   }
 ]
 


### PR DESCRIPTION
I've added 'jenett. simply. personal.' to the sites.js file - a total of 6 keys pertaining to my site located at https://simply.personal.jenett.org (icon and #random link are in place).