### PR TITLE
Add andrewchou.hashbase.io to sites

### DIFF
--- a/scripts/sites.js
+++ b/scripts/sites.js
@@ -868,6 +868,12 @@ const sites = [
     title: 'ashpex',
     type: 'blog',
     url: 'https://ashpex.neocities.org'
+  },
+  
+  {
+    contact: 'andrewchou@tutanota.com',
+    langs: ['en'],
+    url: 'https://andrewchou.hashbase.io'
   }
 ]
 


### PR DESCRIPTION
Icon is located at the bottom of the page, in the sticky footer

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/18542095/77507553-07bc5700-6e3f-11ea-847b-3c05fa5ac4ef.png">
