### PR TITLE
Change PR invite link target.

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,7 +456,7 @@
         This webring is an attempt to inspire artists &amp; developers to build their own website and share traffic among each other. The ring welcomes personalized websites such as <b>diaries, wikis &amp; portfolios</b>.
       </p>
       <p>
-        To add yourself to the ring, submit a <a href="https://github.com/XXIIVV/webring/edit/master/index.html" target="_blank">pull request</a>.<br />
+        To add yourself to the ring, submit a <a href="https://github.com/XXIIVV/webring#join-the-webring" target="_blank">pull request</a>.<br />
         If you found a broken link, please <a href="https://github.com/XXIIVV/webring/issues/new" target="_blank">report it</a>.<br />
         Learn <a href="https://github.com/XXIIVV/webring" target="_blank">more</a> | <a href="#twtxt">Show twtxt</a> | <a href="#rss">Show rss</a><span class='hide'> | <a href='#'>Hide Feeds</a></span>
       </p>


### PR DESCRIPTION
Old href pops an edit window. New href links to instructions.