### PR TITLE
added jacob.chvatal.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,6 +461,9 @@
         <a href="https://nor.the-rn.info">Northern Information</a>
         <a href="https://nor.the-rn.info/feed.xml" class="rss">rss</a>
       </li>
+      <li data-lang="en" id="jacobchvatal">
+        <a href="https://jacob.chvatal.com">Jacob Chvatal</a>
+      </li>
     </ol>
     <footer>
       <p class="readme">


### PR DESCRIPTION
The location of the webring icon is in the bottom left of the text content. 
It's stored in the footer at the leftmost position of the main content of the site,
and as such is visible slightly southwest from the center of the web page.

I have self-hosted the icon.