### PR TITLE
Added deianeira.co to webring, conformed whitespace for preceeding en…

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,9 +465,12 @@
         <a href="https://matildepark.ca">Matilde Park</a>
         <a href="https://matildepark.ca/feed.xml" class="rss">rss</a>
       </li>
-	   <li data-lang="en" id="132">
+      <li data-lang="en" id="132">
         <a href="https://fdisk.space">ƒdisk.space</a>
         <a href="https://fdisk.space/rss.xml" class="rss">rss</a>
+      </li>
+      <li data-lang="en" id="deianeira">
+        <a href="https://deianeira.co">deianeira.co</a>
       </li>
     </ol>
     <footer>


### PR DESCRIPTION
…try.

https://deianeira.co/ webring is placed bottom left of the page in footer.
Also https://deianeira.co/elsewhere/ dead center.