### PR TITLE
Change domain and remove twtxt

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,9 +31,8 @@
         <a href="https://kaemura.com/twttxt.txt" class="twtxt">twtxt</a>
       </li>
       <li data-lang="en" id="5">
-        <a href="https://liamcooke.com">liamcooke</a>
-        <a href="https://liamcooke.com/merveilles/tw.txt" class="twtxt">twtxt</a>
-        <a href="https://liamcooke.com/feed.xml" class="rss">rss</a>
+        <a href="https://bismuth.garden">bismuth.garden</a>
+        <a href="https://bismuth.garden/feed.xml" class="rss">rss</a>
       </li>
       <li data-lang="en" id="6">
         <a href="https://hraew.autophagy.io">hraew.autophagy</a>


### PR DESCRIPTION
Swapping out my stagnant portfolio for a new wiki which I'm planning to maintain.

I stopped using twtxt ages ago so I've removed that link too.