### PR TITLE
Update aklsh.github -> aklsh.now (new domain)

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,7 +361,7 @@
         <a href="https://parkimminent.com">Park Imminent</a>
       </li>
       <li data-lang="en" id="107">
-        <a href="https://aklsh.github.io">aklsh.github</a>
+        <a href="https://aklsh.now.sh">aklsh</a>
       </li>
       <li data-lang="en" id="108">
         <a href="https://0xff.nu">Paul Glushak</a>


### PR DESCRIPTION
Changed my website domain from aklsh.github.io to aklsh.now.sh

The webring icon can now be seen in the landing page and also along with all the social icons in all pages.