### PR TITLE
Add mrshll.com to the webring, link in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,6 +530,9 @@
         <a href="https://0l.wtf/rss.xml" class="rss">rss</a>
         <a href="https://0l.wtf/twtxt.txt" class="twtxt">twtxt</a>
       </li>
+      <li data-lang="en" id="150">
+        <a href="https://mrshll.com">mrshll</a>
+      </li>
     </ol>
     <footer>
       <p class="readme">


### PR DESCRIPTION
You can find the webring link in mrshll.com's `<footer />` on all pages.