### PR TITLE
adding everest-pipkin.com to the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,6 +533,9 @@
       <li data-lang="en" id="150">
         <a href="https://mrshll.com">mrshll</a>
       </li>
+      <li data-lang="en" id="151">
+        <a href="https://everest-pipkin.com/">everest pipkin</a>
+      </li>
     </ol>
     <footer>
       <p class="readme">


### PR DESCRIPTION
adding everest-pipkin.com to the webring. my site uses frames (yes, i know, really) so while the webring link is accessible on every page, the icon is actually at https://everest-pipkin.com/related.html