### PR TITLE
Reduce svg filesize

### DIFF
--- a/icon.black.large.svg
+++ b/icon.black.large.svg
@@ -1,13 +1,1 @@
-<svg class="vector" width="300px" height="300px" xmlns="http://www.w3.org/2000/svg" baseProfile="full" version="1.1" style="fill:none;stroke:black;stroke-width:5px;stroke-linecap:square;">
-  <g transform="translate(0,30)">
-    <g transform="translate(150,150),rotate(120,0,0)">
-      <path d="M0,-60 a60,60 0 1,0 0,120 l100,0"></path>   
-    </g>
-    <g transform="translate(150,150),rotate(240,0,0)">
-      <path d="M0,-60 a60,60 0 1,0 0,120 l100,0"></path>   
-    </g>
-    <g transform="translate(150,150),rotate(0,0,0)">
-      <path d="M0,-60 a60,60 0 1,0 0,120 l100,0"></path>   
-    </g>
-  </g>
-</svg>
+<svg fill="none" height="300" stroke="#000" stroke-linecap="square" stroke-width="5" width="300" xmlns="http://www.w3.org/2000/svg"><path d="M201.962 210a60 60 0 10-103.924-60l-50 86.603"/><path d="M98.038 210a60 60 0 10103.924-60l-50-86.603"/><path d="M150 120a60 60 0 100 120h100"/></svg>

--- a/icon.black.svg
+++ b/icon.black.svg
@@ -1,13 +1,1 @@
-<svg class="vector" width="300px" height="300px" xmlns="http://www.w3.org/2000/svg" baseProfile="full" version="1.1" style="fill:none;stroke:black;stroke-width:28px;stroke-linecap:square;">
-  <g transform="translate(0,30)">
-    <g transform="translate(150,150),rotate(120,0,0)">
-      <path d="M0,-60 a60,60 0 1,0 0,120 l100,0"></path>   
-    </g>
-    <g transform="translate(150,150),rotate(240,0,0)">
-      <path d="M0,-60 a60,60 0 1,0 0,120 l100,0"></path>   
-    </g>
-    <g transform="translate(150,150),rotate(0,0,0)">
-      <path d="M0,-60 a60,60 0 1,0 0,120 l100,0"></path>   
-    </g>
-  </g>
-</svg>
+<svg fill="none" height="300" stroke="#000" stroke-linecap="square" stroke-width="28" width="300" xmlns="http://www.w3.org/2000/svg"><path d="M201.962 210a60 60 0 10-103.924-60l-50 86.603"/><path d="M98.038 210a60 60 0 10103.924-60l-50-86.603"/><path d="M150 120a60 60 0 100 120h100"/></svg>

--- a/icon.white.svg
+++ b/icon.white.svg
@@ -1,13 +1,1 @@
-<svg class="vector" width="300px" height="300px" xmlns="http://www.w3.org/2000/svg" baseProfile="full" version="1.1" style="fill:none;stroke:white;stroke-width:28px;stroke-linecap:square;">
-  <g transform="translate(0,30)">
-    <g transform="translate(150,150),rotate(120,0,0)">
-      <path d="M0,-60 a60,60 0 1,0 0,120 l100,0"></path>   
-    </g>
-    <g transform="translate(150,150),rotate(240,0,0)">
-      <path d="M0,-60 a60,60 0 1,0 0,120 l100,0"></path>   
-    </g>
-    <g transform="translate(150,150),rotate(0,0,0)">
-      <path d="M0,-60 a60,60 0 1,0 0,120 l100,0"></path>   
-    </g>
-  </g>
-</svg>
+<svg fill="none" height="300" stroke="#fff" stroke-linecap="square" stroke-width="28" width="300" xmlns="http://www.w3.org/2000/svg"><path d="M201.962 210a60 60 0 10-103.924-60l-50 86.603"/><path d="M98.038 210a60 60 0 10103.924-60l-50-86.603"/><path d="M150 120a60 60 0 100 120h100"/></svg>


### PR DESCRIPTION
This commit reduces the filesize of the SVG files by over half.

I and other siteowners would like to inline the image into our sites;
minifying and shrinking the filesize improves this.