### PR TITLE
Add len.to

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,6 +552,9 @@
         <a href="https://pbat.ch">pbatch</a>
         <a href="https://pbat.ch/twtxt.txt" class="twtxt">twtxt</a>
       </li>
+      <li data-lang="en" id="lento">
+        <a href="https://len.to">len.to</a>
+      </li>
     </ol>
     <footer>
       <p class="readme">


### PR DESCRIPTION
Adds https://len.to, my personal photography site to the webring.
The webring image is located on the about page, https://len.to/about,
and was added in
https://github.com/bndw/len.to/commit/fc6ae004b058785bbabaa4d8c3dee9cb1d441873