### PR TITLE
Update xj-ix.luxe

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,10 +369,10 @@
         <a href="https://simone.computer">Simone's Computer</a>
         <a href="https://system32.simone.computer/rss.xml" class="rss">rss</a>
       </li>
-      <li data-lang="en" id="110">
+      <li data-lang="en es" id="110">
         <a href="https://xj-ix.luxe">dreamspace</a>
-        <a href="https://xj-ix.luxe/.well-known/webring/tw.txt" class="twtxt">twtxt</a>
-        <a href="https://xj-ix.luxe/rss.xml" class="rss">rss</a>
+        <a href="https://xj-ix.luxe/.well-known/twtxt/xjix.txt" class="twtxt">twtxt</a>
+        <a href="https://xj-ix.luxe/feed.atom" class="rss">rss</a>
       </li>
       <li data-lang="en" id="111">
         <a href="https://simply.personal.jenett.org">jenett. simply. personal.</a>


### PR DESCRIPTION
did some minor site restructuring, updating this to use the canonical urls. the old ones just redirect here.