### PR TITLE
Add sirtetris.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -607,6 +607,9 @@
         <a href="https://マリウス.com">マリウス</a>
         <a href="https://マリウス.com/index.xml" class="rss">rss</a>
       </li>
+      <li data-lang="en de" id="163">
+        <a href="https://sirtetris.com">sirtetris</a>
+      </li>
     </ol>
     <footer>
       <p class="readme">


### PR DESCRIPTION
Added [sirtetris.com](http://sirtetris.com/).

The webring icon/link is at the bottom of all content pages (not the index page).

There's a small about section [here](http://sirtetris.com/?c=misc) and the [hobby section](http://sirtetris.com/?c=hbby) is also in part kind of a self introduction.