### PR TITLE
Add wilde-at-heart.garden

### DIFF
--- a/index.html
+++ b/index.html
@@ -622,6 +622,11 @@
       <li data-lang="en" id="nilfm">
         <a href="https://nilfm.cc">nilFM</a>
       </li>
+      <li data-lang="en" id="wilde-at-heart">
+        <a href="https://wilde-at-heart.garden">wilde at heart</a>
+        <a href="https://wilde-at-heart.garden/txtwt.txt" class="twtxt">twtxt</a>
+        <a href="https://wilde-at-heart.garden/notes/feed.xml" class="rss">rss</a>
+      </li>
     </ol>
     <footer>
       <p class="readme">


### PR DESCRIPTION
Hello!

I would love if my digital garden could be added to the webring. I am just getting up and running, but I already have some content pages. I know the criteria say that blog posts do not count, but do digital garden "seed" pages count as blogs? If they don't, I completely understand!

The webring link is included in my footer, which is on all pages that aren't the root page (which has no footer) or my CV page.

<img width="985" alt="Screen Shot 2021-05-30 at 10 36 48 PM" src="https://user-images.githubusercontent.com/17013952/120132144-d0aaa980-c197-11eb-9463-5dbe811bcfbb.png">
<img width="985" alt="Screen Shot 2021-05-30 at 10 36 16 PM" src="https://user-images.githubusercontent.com/17013952/120132160-d607f400-c197-11eb-9996-b451b006bb73.png">

