### PR TITLE
add astrid.tech

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,6 +654,10 @@
         <a href="https://yhnck.xyz">yhancik</a>
         <img src="https://yhnck.xyz/button.gif"/>
       </li>
+      <li data-lang="en" id="astralbijection">
+        <a href="https://astrid.tech">astral&harr;bijection</a>
+        <a href="https://astrid.tech/atom.xml" class="rss">rss</a>
+      </li>
     </ol>
     <footer>
       <p class="readme">


### PR DESCRIPTION
This adds https://astrid.tech to the webring.

The webring link is in the footer. 

Most of my non-blog content pages are located under [/projects](https://astrid.tech/projects).