### PR TITLE
Moved .gif location on opguides.info

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
       </li>
       <li data-lang="en" id="83">
         <a href="https://opguides.info">OpGuides</a>
-        <img src="https://opguides.info/opguides3.gif" alt="gradient hue shift">
+        <img src="https://opguides.info/nonfree/logo/opguides3.gif" alt="gradient hue shift">
       </li>
       <li data-lang="en" id="84">
         <a href="https://chrismaughan.com/">CMaughan</a>


### PR DESCRIPTION
Necessary for a rework of the licencing of opguides to be more-or-less CC-BY-NC-SA instead of the nightmare it was before