### PR TITLE
README: Fix link to index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This [webring](https://wiki.xxiivv.com/webring) is an attempt to inspire artists
 ```
 
 1) Add the webring icon to your website html.
-2) Add your website information to the [index.html](https://github.com/XXIIVV/webring/edit/master/index.html) file. Keep your link name short, and don't leave a trailing `/` in the `href` attribute. Use a sensible alphanumeric value for the id.
+2) Add your website information to the [index.html](index.html) file. Keep your link name short, and don't leave a trailing `/` in the `href` attribute. Use a sensible alphanumeric value for the id.
 3) Submit a Pull Request with **the location of the webring icon** on your site. Pull requests with blank descriptions will be rejected.
 
 Alternatively, if you your website has a dark background, use `icon.white.svg`. If your website is complaining about *https*, go ahead and host the icon yourself.


### PR DESCRIPTION
The index link in README.md links to the file on a non-existent Git branch. This PR changes the link to use [GitHub's support for relative links][1], which ensures the link works independently of any branch.

[1]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes#relative-links-and-image-paths-in-readme-files