### PR TITLE
Add `giacintocarlucci.it` to webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,6 +669,9 @@
         <a href="https://noelle.dev">noelle.dev</a>
         <img src="https://noelle.dev/assets/images/button.gif" alt="noelle.dev webring banner"/>
       </li>
+      <li data-lang="en" id="giacinto-carlucci">
+        <a href="https://www.giacintocarlucci.it">giacintocarlucci.it</a>
+      </li>
     </ol>
     <footer>
       <p class="readme">


### PR DESCRIPTION
[giacintocarlucci.it][1] is a personal knowledge base where I like to share projects, blog posts and notes [2] about mostly everything new I can learn as a developer (with some extra arguments pages about my hobbies)[3]

I've added the webring icon on the right side of the footer.
The website is just HTML and a bunch of CSS lines, no Javascript.

[1]: https://www.giacintocarlucci.it
[2]: https://www.giacintocarlucci.it/docs/memex
[3]: https://www.giacintocarlucci.it/docs/photography