### PR TITLE
Add paritybit.ca

### DIFF
--- a/index.html
+++ b/index.html
@@ -672,6 +672,10 @@
       <li data-lang="en" id="giacinto-carlucci">
         <a href="https://www.giacintocarlucci.it">giacintocarlucci.it</a>
       </li>
+      <li data-lang="en" id="paritybit">
+        <a href="https://www.paritybit.ca">paritybit.ca</a>
+        <a href="https://www.paritybit.ca/feed.xml" class="rss">rss</a>
+      </li>
     </ol>
     <footer>
       <p class="readme">


### PR DESCRIPTION
The location of the webring icon is on the bottom right of every page on the site (on the right side of the footer).