### PR TITLE
deleting my blog from the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,10 +374,6 @@
 				<a href="http://xj-ix.luxe/feed.atom" class="rss">rss</a>
 				<img src="http://xj-ix.luxe/activelink.gif" />
 			</li>
-			<li data-lang="en" id="111">
-				<a href="https://simply.personal.jenett.org">jenett. simply. personal.</a>
-				<a href="https://simply.personal.jenett.org/feed" class="rss">rss</a>
-			</li>
 			<li data-lang="en" id="112">
 				<a href="http://q.pfiffer.org/">q.pfiffer.org</a>
 				<a href="http://q.pfiffer.org/feed.xml" class="rss">rss</a>


### PR DESCRIPTION
Change made to remove https://simply.personal.jenett.org from the webring.