### PR TITLE
adding aphrodite.dev + security fix?

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This [webring](https://wiki.xxiivv.com/webring) is an attempt to inspire artists
 ## Join the webring
 
 ```html
-<a href="https://webring.xxiivv.com/#your-id-here" target="_blank">
+<a href="https://webring.xxiivv.com/#your-id-here" target="_blank" rel="noopener">
   <img src="https://webring.xxiivv.com/icon.black.svg" alt="XXIIVV webring"/>
 </a>
 ```

--- a/index.html
+++ b/index.html
@@ -713,6 +713,11 @@
 			<li data-lang="en" id="sindhulive">
 				<a href="https://sindhu.live">sindhu.live</a>
 			</li>
+			<li data-lang="en" id="aphrodite.dev">
+				<a href="https://www.aphrodite.dev/">aphrodite.dev</a>
+				<a href="https://www.aphrodite.dev/~blog/feed.xml" class="rss">rss</a>
+				<img src="https://www.aphrodite.dev/badge.gif"/>
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
Hi!
The backlink is available on the website's footer, and also on [the link garden](https://www.aphrodite.dev/~resources/) page.

I also included a patch for the README, to avoid the bad behaviour that happens without `rel=noopener` (page takeover). It won't fix if people leave that out on their own website, but the easy copy/paste won't have this issue anymore at least.