### PR TITLE
Add canalswans to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -738,6 +738,10 @@
         <a href="https://kae.si/feed.xml" class="rss">rss</a>
         <img src="https://kae.si/static/icons/wyrm.svg"/>
       </li>
+			<li data-lang="en" id="canalswans">
+				<a href="https://canalswans.commoninternet.net">canalswans</a>
+				<a href="https://canalswans.commoninternet.net/rss.xml" class="rss">rss</a>
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
I've added a wiki/digital garden to my site (still/forever in progress) and would like to add it to the webring (something I'd been hoping to do for some time, and finally got around to). 

The link to the webring appears on the about page, 
https://canalswans.commoninternet.net/about/