### PR TITLE
added emile.space

### DIFF
--- a/index.html
+++ b/index.html
@@ -752,6 +752,10 @@
 			<li data-lang="en" id="chotrin">
 				<a href="https://chotrin.org">chötrin's wiki.</a>
 			</li>
+			<li data-lang="en" id="emile">
+				<a href="https://emile.space">emile.space.</a>
+	  			<a href="https://emile.space/twtxt.txt" class="twtxt">twtxt</a>
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
After rewriting my static site generator [vokobe](https://git.sr.ht/~hanemile/vokobe) in the beginning of the year, [emile.space](https://emile.space) has reached a form in which I'd like to submit it. I've tested it using `netsurf` where it looks quite rudimentary, although still fully functional (I'd argue it looks even cleaner completely without css in `lynx`). 

The webring icon is located at the bottom right of each page in the footer.