### PR TITLE
Add plungepool wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -779,7 +779,7 @@
 				<a href="https://guerrero.ph/rss.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en" id="plungepool">
-				<a href="https://wiki.plungepool.dev/">plungepool</a>
+				<a href="https://wiki.plungepool.dev">plungepool</a>
 			</li>
 		</ol>
 		<footer>

--- a/index.html
+++ b/index.html
@@ -778,6 +778,9 @@
 				<a href="https://guerrero.ph">guerrero.ph</a>
 				<a href="https://guerrero.ph/rss.xml" class="rss">rss</a>
 			</li>
+			<li data-lang="en" id="plungepool">
+				<a href="https://wiki.plungepool.dev/">plungepool</a>
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
Adding my new wiki for consideration, webring icon is in the footer: https://wiki.plungepool.dev

I've been a reader and fan of the xxiivv wiki for a couple years now and always really wanted to create something like that for myself, hopefully it is acceptable in its current state. I have about 15 content pages so far not including the organizational "hub" pages that are lists of links to other pages. I wrote a simple custom static site generator to manage the site which can be found here - https://github.com/plungepool/wiki-dot-plungepool-dot-dev