### PR TITLE
Change domain bismuth.garden to detritus.zone

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,8 +33,9 @@
 				<a href="https://kaemura.com/twttxt.txt" class="twtxt">twtxt</a>
 			</li>
 			<li data-lang="en" id="5">
-				<a href="https://bismuth.garden">bismuth.garden</a>
-				<a href="https://bismuth.garden/feed.xml" class="rss">rss</a>
+				<a href="https://detritus.zone">detritus.zone</a>
+				<a href="https://detritus.zone/feed.xml" class="rss">rss</a>
+				<img src="https://detritus.zone/img/detritus.zone-88x31.png" />
 			</li>
 			<li data-lang="en" id="6">
 				<a href="https://hraew.autophagy.io">hraew.autophagy</a>


### PR DESCRIPTION
I'd like to change my domain in the list, as I've just moved everything from <https://bismuth.garden> to <https://detritus.zone>.

I noticed we can link to 88x31 buttons now, so I had to make one of those too. ❤️ 

Thanks!