### PR TITLE
Remove c16.one from the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,9 +764,6 @@
 				<a href="https://tosatur.com">tosatur</a>
 				<a href="https://tosatur.com/notes/rss.xml" class="rss">rss</a>
 			</li>
-			<li data-lang="en" id="C16.one">
-				<a href="https://c16.one">C16.one</a>
-			</li>
 			<li data-lang="en" id="pfych">
 				<a href="https://pfy.ch">pfych</a>
 				<a href="https://pfy.ch/rss.xml" class="rss">rss</a>


### PR DESCRIPTION
Due to personal reasons I won't continue C16.one which is why it should be removed from the webring. Sorry for the inconvenience