### PR TITLE
Remove broken URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,6 @@
 			</li>
 			<li data-lang="en" id="91">
 				<a href="https://sixey.es/">sixey.es</a>
-				<a href="https://sixey.es/feed.xml" class="rss">rss</a>
 				<img src="https://sixey.es/6e20ass/8831.gif" />
 			</li>
 			<li data-lang="en" id="92">
@@ -347,7 +346,6 @@
 			</li>
 			<li data-lang="en" id="108">
 				<a href="https://0xff.nu">Paul Glushak</a>
-				<a href="https://0xff.nu/feed.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en ita" id="109">
 				<a href="https://simone.computer">Simone's Computer</a>
@@ -456,7 +454,6 @@
 			</li>
 			<li data-lang="en" id="137">
 				<a href="https://www.milofultz.com">milofultz</a>
-				<a href="https://milofultz.com/atom.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en" id="138">
 				<a href="https://thomasorus.com">Thomasorus</a>
@@ -569,7 +566,6 @@
 			<li data-lang="en" id="wilde-at-heart">
 				<a href="https://wilde-at-heart.garden">wilde at heart</a>
 				<a href="https://wilde-at-heart.garden/txtwt.txt" class="twtxt">twtxt</a>
-				<a href="https://wilde-at-heart.garden/notes/feed.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en" id="166">
 				<a href="https://voidjumper.glass">voidjumper.glass</a>
@@ -651,7 +647,6 @@
 			</li>
 			<li data-lang="en fr de" id="arcade">
 				<a href="https://arcades.agency">Aethopica</a>
-				<a href="https://arcades.agency/links/rss.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en de fr" id="jachere">
 				<a href="https://jache.re">jache.re</a>
@@ -671,7 +666,6 @@
 			</li>
 			<li data-lang="en" id="tonesupport">
 				<a href="https://log.tone.support">tone.support</a>
-				<a href="https://log.tone.support/log.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en" id="armaina">
 				<a href="http://armaina.com/">armaina</a>

--- a/index.html
+++ b/index.html
@@ -700,7 +700,6 @@
 			</li>
 			<li data-lang="en" id="canalswans">
 				<a href="https://canalswans.commoninternet.net">canalswans</a>
-				<a href="https://canalswans.commoninternet.net/rss.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en" id="erin">
 				<a href="https://erinbern.com">Erin Bern</a>
@@ -734,7 +733,6 @@
 			</li>
 			<li data-lang="en" id="guerrero">
 				<a href="https://guerrero.ph">guerrero.ph</a>
-				<a href="https://guerrero.ph/rss.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en" id="nebula">
 				<a href="https://nebula.ed1.club/stuff/">nebula.ed1.club</a>

--- a/index.html
+++ b/index.html
@@ -731,9 +731,6 @@
 			<li data-lang="en" id="kxvin">
 				<a href="https://www.kxvin.com">kxvin</a>
 			</li>
-			<li data-lang="en" id="guerrero">
-				<a href="https://guerrero.ph">guerrero.ph</a>
-			</li>
 			<li data-lang="en" id="nebula">
 				<a href="https://nebula.ed1.club/stuff/">nebula.ed1.club</a>
 			</li>


### PR DESCRIPTION
This PR removes the following URLs:

**URLs that return a 404 error:**
- https://sixey.es/feed.xml
- https://0xff.nu/feed.xml
- https://milofultz.com/atom.xml
- https://wilde-at-heart.garden/notes/feed.xml
- https://arcades.agency/links/rss.xml
- https://log.tone.support/log.xml

**URL with certificate issue:**
- https://canalswans.commoninternet.net/rss.xml

**URLs where the server is no longer responding:**
- https://guerrero.ph/rss.xml
- https://guerrero.ph/