### PR TITLE
Remove broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
 			<li data-lang="en" id="avanier">
 				<a href="https://avanier.dev">avanier</a>
 				<a href="https://avanier.dev/tw.txt" class="twtxt">twtxt</a>
-				<img src='https://avanier.dev/m/88x31.gif' />
 			</li>
 			<li data-lang="en" id="5">
 				<a href="https://detritus.zone">detritus.zone</a>
@@ -130,7 +129,6 @@
 			</li>
 			<li data-lang="en" id="39">
 				<a href="https://drisc.io">drisc</a>
-				<a href="https://drisc.io/hallway/twtxt.txt" class="twtxt">twtxt</a>
 			</li>
 			<li data-lang="en" id="40">
 				<a href="https://ricky.codes">ricky.codes</a>
@@ -146,9 +144,6 @@
 			</li>
 			<li data-lang="en" id="44">
 				<a href="https://nomand.co">nomand.co</a>
-			</li>
-			<li data-lang="en" id="45">
-				<a href="http://memoriata.com">memoriata</a>
 			</li>
 			<li data-lang="en" id="46">
 				<a href="https://mmm.s-ol.nu">s-ol.nu</a>
@@ -177,7 +172,6 @@
 			</li>
 			<li data-lang="en" id="53">
 				<a href="https://phse.net">phse.net</a>
-				<a href="https://phse.net/twtxt/merv.txt" class="twtxt">twtxt</a>
 				<a href="https://phse.net/post/index.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en" id="54">
@@ -198,7 +192,6 @@
 			</li>
 			<li data-lang="en" id="61">
 				<a href="https://hex22.org">hex22</a>
-				<a href="https://t.seed.hex22.org/twtxt.txt" class="twtxt">twtxt</a>
 			</li>
 			<li data-lang="en" id="62">
 				<a href="https://patrikarvidsson.com">patrikarvidsson</a>
@@ -212,9 +205,6 @@
 			<li data-lang="en" id="65">
 				<a href="https://mboxed.github.io/sodatsu">sodatsu</a>
 				<a href="https://mboxed.github.io/sodatsu/tw.txt" class="twtxt">twtxt</a>
-			</li>
-			<li data-lang="en" id="66">
-				<a href="https://letters.vexingworkshop.com">vexingworkshop</a>
 			</li>
 			<li data-lang="en" id="67">
 				<a href="https://tom.so">tom hackshaw</a>
@@ -331,18 +321,12 @@
 			<li data-lang="en cz" id="103">
 				<a href="https://estfyr.net">estfyr.net</a>
 			</li>
-			<li data-lang="en" id="104">
-				<a href="https://paysonwallach.com">paysonwallach.com</a>
-			</li>
 			<li data-lang="en" id="105">
 				<a href="https://natwelch.com">Nat Welch</a>
 				<a href="https://writing.natwelch.com/feed.rss" class="rss">rss</a>
 			</li>
 			<li data-lang="en" id="106">
 				<a href="https://parkimminent.com">Park Imminent</a>
-			</li>
-			<li data-lang="en" id="107">
-				<a href="https://aklsh.now.sh">aklsh</a>
 			</li>
 			<li data-lang="en" id="108">
 				<a href="https://0xff.nu">Paul Glushak</a>
@@ -511,11 +495,6 @@
 				<a href="https://darch.dk/twtxt.txt" class="twtxt">twtxt</a>
 				<a href="https://darch.dk/feed/page:feed.xml" class="rss">rss</a>
 			</li>
-			<li data-lang="en" id="natehn">
-				<a href="https://natehn.com">natehn</a>
-				<a href="https://natehn.com/index.xml" class="rss">rss</a>
-				<img src='https://natehn.com/animated-icon.gif' />
-			</li>
 			<li data-lang="en" id="pbatch">
 				<a href="https://pbat.ch">pbatch</a>
 				<a href="https://pbat.ch/twtxt.txt" class="twtxt">twtxt</a>
@@ -565,7 +544,6 @@
 			</li>
 			<li data-lang="en" id="wilde-at-heart">
 				<a href="https://wilde-at-heart.garden">wilde at heart</a>
-				<a href="https://wilde-at-heart.garden/txtwt.txt" class="twtxt">twtxt</a>
 			</li>
 			<li data-lang="en" id="166">
 				<a href="https://voidjumper.glass">voidjumper.glass</a>
@@ -581,10 +559,6 @@
 			</li>
 			<li data-lang="en" id="maxhaesslein">
 				<a href="https://www.maxhaesslein.de">maxhaesslein.de</a>
-			</li>
-			<li data-lang="en" id="dyslexic-ink">
-				<a href="https://dyslexic.ink">dyslexic.ink</a>
-				<img src="https://dyslexic.ink/images/pong-88x31.gif" />
 			</li>
 			<li data-lang="en" id="compudanzas">
 				<a href="https://compudanzas.net">compudanzas</a>
@@ -653,7 +627,6 @@
 			</li>
 			<li data-lang="en" id="oddblog">
 				<a href="https://blog.odd.codes">oddblog</a>
-				<a href="https://odd.codes/tw.txt" class="twtxt">twtxt</a>
 				<img src="https://odd.codes/oddchase.gif"/>
 			</li>
 			<li data-lang="en" id="helveticablanc">

--- a/index.html
+++ b/index.html
@@ -358,7 +358,6 @@
 			</li>
 			<li data-lang="en fr" id="117">
 				<a href="https://www.mentalnodes.com">Mental Nodes</a>
-				<a href="https://www.mentalnodes.com/sitemap.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="es" id="118">
 				<a href="https://copiona.com">copiona</a>

--- a/index.html
+++ b/index.html
@@ -124,9 +124,6 @@
 				<a href="http://nonmateria.com/rss.xml" class="rss">rss</a>
 				<img src="http://nonmateria.com/data/avatars/banner.gif" alt="nonmateria.com webring banner">
 			</li>
-			<li data-lang="en" id="38">
-				<a href="https://underscorediscovery.ca">underscorediscovery</a>
-			</li>
 			<li data-lang="en" id="39">
 				<a href="https://drisc.io">drisc</a>
 			</li>


### PR DESCRIPTION
I'm back with another cleanup PR. Below is the list of removed URLs, categorized by error type.

**404 not found:**
- https://avanier.dev/m/88x31.gif
- https://phse.net/twtxt/merv.txt
- https://aklsh.now.sh/
- https://wilde-at-heart.garden/txtwt.txt
- https://odd.codes/tw.txt

**SSL handshake error:**
- https://t.seed.hex22.org/twtxt.txt
- https://dyslexic.ink/
- https://dyslexic.ink/images/pong-88x31.gif

**500 Internal server error:**
- https://drisc.io/hallway/twtxt.txt

**503 Service unavailable:**
- https://letters.vexingworkshop.com/

**Host not found:**
- http://memoriata.com/
- https://underscorediscovery.ca/

**Connect error:**
- https://paysonwallach.com

**Sitemap mislabeled as RSS feed:**
- https://www.mentalnodes.com/sitemap.xml
