### PR TITLE
Add link to feed reader

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,6 +764,7 @@
 			<p>
 				To add yourself to the ring, submit a <a href="https://github.com/XXIIVV/webring#join-the-webring" target="_blank">pull request</a>.<br />
 				Looking for something specific, use the <a href="https://lieu.cblgh.org" target="_blank">search</a>.<br />
+				To see the latest RSS content, use the <a href="https://webring.chad.is" target="_blank">feed reader</a>.<br />
 				Found a broken link, please <a href="https://github.com/XXIIVV/webring/issues/new" target="_blank">report it</a>.<br /><br />
 				<a href="#icons">Show icons</a> | <a href="#twtxt">Show twtxt</a> | <a href="#rss">Show rss</a><span class="hide"> | <a href="#">Hide Feeds</a></span> | <a href="https://lieu.cblgh.org/random" target="_blank">Random</a>
 			</p>


### PR DESCRIPTION
I've been working on a small side project to produce a RSS feed reader for all the blogs in the webring with a (valid) RSS feed:

https://webring.chad.is

The blogs are sorted by most recently updated, but I've chosen a UX that prevents frequently updated blogs from dominating the view.

This PR suggests a link in the footer, below the link to the external search tool.

Happy to hear feedback on either the placement or wording of the link, or to the RSS reader tool itself. I intend on continuing to work on it and introduce some performance improvements and better handling of malformed feeds.
