### PR TITLE
Add manifoldslug to webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -756,6 +756,10 @@
 				<a href="https://pfy.ch">pfych</a>
 				<a href="https://pfy.ch/rss.xml" class="rss">rss</a>
 			</li>
+			<li data-lang="en" id="manifoldslug">
+				<a href="http://wreckage.link">manifoldslug</a>
+				<a href="http://wreckage.link/rss.xml" class="rss">rss</a>
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
The webring icon is at the bottom of the index page.