### PR TITLE
add cathos.net as #204

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,6 +770,9 @@
 			<li data-lang="en" id="wilbur">
 				<a href="https://wilburzhang.com">Wilbur Zhang</a>
 			</li>
+			<li data-lang="en" id="204">
+				<a href="https://cathos.net">cathos</a>
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
webring icons are in /images ( www.cathos.net/images/icon.white.svg ), and displayed in header>nav on index and all other pages.