### PR TITLE
Add grains.cc to the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -776,6 +776,10 @@
 			<li data-lang="en" id="zinzy">
 				<a href="https://zinzy.website">Zinzy Waleson Geene</a>
 				<a href="https://www.zinzy.website/feed.xml" class="rss">rss</a>
+			</li>
+			<li data-lang="en" id="grains">
+				<a href="https://grains.cc">grains.cc</a>
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
Hi! I've been lurking on merveilles.town and the webring since I stumbled upon the [decentralized web thread on lines](https://llllllll.co/t/email-newsletters-low-tech-decentralized-web/34878/128?u=nshe) a few years back but couldn't put my own wiki together until this year. Would be glad to see grains accepted, or otherwise get any feedback!

Quick link: https://grains.cc/

All the pages that qualify for the 10 pages threshold can be found under [/notes](https://grains.cc/notes/), and the webring icon is located in the footer. There is no javascript required for viewing the website, but some pages fetch external JS to embed music and videos, and on top of that there's the cloudflare analytics script, let me know if that could become a problem. 