### PR TITLE
noelle.dev: Use image-rendering: pixelated

### DIFF
--- a/index.html
+++ b/index.html
@@ -577,7 +577,12 @@
 			</li>
 			<li data-lang="en" id="noelle-dev">
 				<a href="https://noelle.dev">noelle.dev</a>
-				<img loading="lazy" src="https://noelle.dev/assets/images/button.gif" alt="noelle.dev webring banner"/>
+				<img
+					loading="lazy"
+					src="https://noelle.dev/assets/images/button.gif"
+					alt="noelle.dev webring banner"
+					style="image-rendering: pixelated;"
+				/>
 			</li>
 			<li data-lang="en" id="giacinto-carlucci">
 				<a href="https://www.giacintocarlucci.it">giacintocarlucci.it</a>


### PR DESCRIPTION
Since my banner is a 1-bit GIF, nearest-neighbor rendering keeps it crisp at any size.