### PR TITLE
Add bbo.do to the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,6 +239,9 @@
 				<a href="https://gosha.net/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://gosha.net/assets/images/88x31.svg" alt="gosha.net banner">
 			</li>
+			<li data-lang="en" id="bodo">
+				<a href="https://bbo.do">Bodo Braegger</a>
+			</li>
 			<li data-lang="en" id="81">
 				<a href="https://www.tatecarson.com">Tate Carson</a>
 			</li>


### PR DESCRIPTION
I would love to add my personal homepage, [bbo.do](https://bbo.do), to the webring. I have added the icon in a link in the global navbar, present on all subpages. It should render on the top right, next to the github icon, and the button to change the theme.

If at all possible, I would love to be able to land at number 64. I have added the entry at the approximate location, but I'm guessing this is subject to change due to dead links being pruned.

Your projects are a cotinuous inspiration, thanks a ton.

`xoxo`
`bodo`