### PR TITLE
Add blog.shr4pnel.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -801,6 +801,10 @@
 				<a href="https://kjelsrud.dev">kjelsrud.dev</a>
 				<a href="https://kjelsrud.dev/rss.xml" class="rss">rss</a>
 			</li>
+            <li data-lang="en" id="shrapnelnet">
+                <a href="https://blog.shr4pnel.com">blog.shr4pnel.com</a>
+                <a href="https://blog.shr4pnel.com/feed.xml" class="rss">rss</a>
+            </li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
Added my blog to the list. website is hosted at https://blog.shr4pnel.com and the link to xxiivv is in the middle of the page under the "socials" header.

cheers!