### PR TITLE
Add ‘jakintosh.com’ to the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,6 +817,9 @@
 		<a href="https://lunabee.space/beespace.atom" class="rss">rss</a>
 		<img loading="lazy" src="https://lunabee.space/8831.gif"/>
 	</li>
+			<li data-lang="en" id="jakintosh">
+				<a href="http://jakintosh.com">jakintosh.com</a>
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
The webring icon can be found at the bottom of every page, in the footer.

Quick link: http://jakintosh.com/index.html#footer