### PR TITLE
Hardcode <img> dimensions to prevent reflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ To add an extra feed to your entry, add them within your `<li>` tag as follow:
   <a href="https://wiki.xxiivv.com">xxiivv</a>
   <a href="https://wiki.xxiivv.com/links/tw.txt" class="twtxt">twtxt</a>
   <a href="https://wiki.xxiivv.com/links/rss.xml" class="rss">rss</a>
-  <img src="https://wiki.xxiivv.com/media/services/button.gif"/>
+  <img
+    src="https://wiki.xxiivv.com/media/services/button.gif"
+    alt="xxiivv webring icon"
+    width="88"
+    height="31"
+  >
 </li>
 ```
 
@@ -45,7 +50,7 @@ Instead of linking to the directory, you can also link to the next link in the r
 
 ```html
 <a href="https://webring.xxiivv.com/#xxiivv" target="_blank" rel="noopener noreferrer">
-  <img src="https://webring.xxiivv.com/icon.black.svg" alt="XXIIVV webring"/>
+  <img src="https://webring.xxiivv.com/icon.black.svg" alt="XXIIVV webring" width="300" height="300">
 </a>
 ```
 

--- a/index.html
+++ b/index.html
@@ -845,7 +845,7 @@
 			body a:after { content: '}'; }
 			body > ol { margin: 30px; padding: 0px 30px 30px; column-count: 3; display: block; border-bottom: 2px solid var(--color-beta); }
 			body > ol > li { padding-right: 30px; }
-			body > ol > li img { display: none; margin:5px; max-width: 88px; height: auto; }
+			body > ol > li img { display: none; margin: 5px; max-width: 88px; height: auto; font-style: italic; overflow: hidden; }
 			body > ol > li a.rss, body > ol > li a.twtxt { display: none; }
 			body > ol > li a:visited:before, body > ol > li a:visited:after { color: var(--color-alpha); }
 			body > footer { margin: 30px; }

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 				<a href="https://wiki.xxiivv.com">xxiivv</a>
 				<a href="https://wiki.xxiivv.com/links/tw.txt" class="twtxt">twtxt</a>
 				<a href="https://wiki.xxiivv.com/links/rss.xml" class="rss">rss</a>
-				<img loading="lazy" src='https://wiki.xxiivv.com/media/services/button.gif' />
+				<img loading="lazy" src='https://wiki.xxiivv.com/media/services/button.gif' width="88" height="31">
 			</li>
 			<li data-lang="en" id="2">
 				<a href="https://electro.pizza">electro pizza</a>
@@ -27,7 +27,7 @@
 			<li data-lang="en" id="5">
 				<a href="https://detritus.zone">detritus.zone</a>
 				<a href="https://detritus.zone/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://detritus.zone/img/detritus.zone-88x31.png" />
+				<img loading="lazy" src="https://detritus.zone/img/detritus.zone-88x31.png" width="88" height="31">
 			</li>
 			<li data-lang="en" id="6">
 				<a href="https://hraew.autophagy.io">hraew.autophagy</a>
@@ -39,7 +39,7 @@
 			<li data-lang="en" id="12">
 				<a href="https://now.lectronice.com">lectronice</a>
 				<a href="https://now.lectronice.com/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://now.lectronice.com/lctrncbttn.gif" />
+				<img loading="lazy" src="https://now.lectronice.com/lctrncbttn.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="13">
 				<a href="https://craze.co.uk">craze.co.uk</a>
@@ -50,12 +50,12 @@
 			<li data-lang="en" id="15">
 				<a href="https://cblgh.org">cblgh</a>
 				<a href="https://cblgh.org/all.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://cblgh.org/dl/cblgh-webring.gif" alt="cblgh.org webring banner">
+				<img loading="lazy" src="https://cblgh.org/dl/cblgh-webring.gif" alt="cblgh.org webring banner" width="88" height="31">
 			</li>
 			<li data-lang="en" id="16">
 				<a href="https://ellugar.co">ellugar</a>
 				<a href="http://feeds.ellugar.co/ellugar-logs" class="rss">rss</a>
-				<img loading="lazy" src="https://ellugar.co/img/button.gif" alt="ellugar.co banner">
+				<img loading="lazy" src="https://ellugar.co/img/button.gif" alt="ellugar.co banner" width="88" height="31">
 			</li>
 			<li data-lang="en" id="17">
 				<a href="http://chigby.org">chigby</a>
@@ -67,7 +67,7 @@
 			<li data-lang="en" id="19">
 				<a href="https://palomakop.tv">palomakop.tv</a>
 				<a href="https://palomakop.tv/rss.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://palomakop.tv/button.gif" alt="palomakop.tv banner">
+				<img loading="lazy" src="https://palomakop.tv/button.gif" alt="palomakop.tv banner" width="88" height="31">
 			</li>
 			<li data-lang="en" id="20">
 				<a href="https://v-os.ca">v-os.ca</a>
@@ -90,7 +90,7 @@
 			</li>
 			<li data-lang="en" id="28">
 				<a href="http://kokorobot.ca">kokorobot.ca</a>
-				<img loading="lazy" src="https://kokorobot.ca/media/interface/button.gif" alt="kokorobot"/>
+				<img loading="lazy" src="https://kokorobot.ca/media/interface/button.gif" alt="kokorobot" width="88" height="31">
 				<a href="https://kokorobot.ca/links/rss.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en" id="29">
@@ -100,7 +100,7 @@
 			<li data-lang="en" id="30">
 				<a href="https://wake.st">wake.st</a>
 				<a href="https://wake.st/twtxt.txt" class="twtxt">twtxt</a>
-				<img loading="lazy" src="https://wake.st/webring/banner.gif" alt="wake.st webring banner">
+				<img loading="lazy" src="https://wake.st/webring/banner.gif" alt="wake.st webring banner" width="88" height="31">
 			</li>
 			<li data-lang="en" id="31">
 				<a href="https://xarene.la">xarene.la</a>
@@ -117,7 +117,7 @@
 			<li data-lang="en" id="37">
 				<a href="http://nonmateria.com">nonmateria</a>
 				<a href="http://nonmateria.com/rss.xml" class="rss">rss</a>
-				<img loading="lazy" src="http://nonmateria.com/data/avatars/banner.gif" alt="nonmateria.com webring banner">
+				<img loading="lazy" src="http://nonmateria.com/data/avatars/banner.gif" alt="nonmateria.com webring banner" width="88" height="31">
 			</li>
 			<li data-lang="en" id="39">
 				<a href="https://drisc.io">drisc</a>
@@ -154,7 +154,7 @@
 			<li data-lang="en" id="50">
 				<a href="https://ritualdust.com">ritual dust</a>
 				<a href="https://ritualdust.com/index.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://ritualdust.com/img/button.gif" />
+				<img loading="lazy" src="https://ritualdust.com/img/button.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="51">
 				<a href="https://magoz.is">magoz.is</a>
@@ -170,7 +170,7 @@
 			<li data-lang="en" id="54">
 				<a href="https://rosano.ca">rosano.ca</a>
 				<a href="https://rosano.ca/feed" class="rss">rss</a>
-				<img loading="lazy" src="https://static.rosano.ca/_shared/webring-button.gif" alt="rosano.ca logo coloured, duplicated, and rotated to appear infinite fractal">
+				<img loading="lazy" src="https://static.rosano.ca/_shared/webring-button.gif" alt="rosano.ca logo coloured, duplicated, and rotated to appear infinite fractal" width="88" height="31">
 			</li>
 			<li data-lang="en" id="56">
 				<a href="https://gndclouds.cc">gndclouds.cc</a>
@@ -230,12 +230,12 @@
 			<li data-lang="en" id="79">
 				<a href="https://eli.li">eli.li</a>
 				<a href="https://eli.li/feed.rss" class="rss">rss</a>
-				<img loading="lazy" src="https://eli.li/_assets/_images/badge/02_88x31.png" alt="Oatmeal badge">
+				<img loading="lazy" src="https://eli.li/_assets/_images/badge/02_88x31.png" alt="Oatmeal badge" width="88" height="31">
 			</li>
 			<li data-lang="en" id="80">
 				<a href="https://gosha.net">gosha.net</a>
 				<a href="https://gosha.net/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://gosha.net/assets/images/88x31.svg" alt="gosha.net banner">
+				<img loading="lazy" src="https://gosha.net/assets/images/88x31.svg" alt="gosha.net banner" width="88" height="31">
 			</li>
 			<li data-lang="en" id="81">
 				<a href="https://www.tatecarson.com">Tate Carson</a>
@@ -246,7 +246,7 @@
 			</li>
 			<li data-lang="en" id="83">
 				<a href="https://opguides.info">OpGuides</a>
-				<img loading="lazy" src="https://opguides.info/nonfree/logo/opguides3.gif" alt="gradient hue shift">
+				<img loading="lazy" src="https://opguides.info/nonfree/logo/opguides3.gif" alt="gradient hue shift" width="88" height="31">
 			</li>
 			<li data-lang="en" id="84">
 				<a href="https://chrismaughan.com/">CMaughan</a>
@@ -269,11 +269,11 @@
 			<li data-lang="en" id="90">
 				<a href="https://resevoir.net">resevoir</a>
 				<a href="https://resevoir.net/rss.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://resevoir.net/images/button.gif" />
+				<img loading="lazy" src="https://resevoir.net/images/button.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="91">
 				<a href="https://sixey.es/">sixey.es</a>
-				<img loading="lazy" src="https://sixey.es/6e20ass/8831.gif" />
+				<img loading="lazy" src="https://sixey.es/6e20ass/8831.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="92">
 				<a href="https://tilde.town/~dustin/">0xdstn</a>
@@ -282,7 +282,7 @@
 			<li data-lang="en" id="93">
 				<a href="https://jameschip.io">James Chip</a>
 				<a href="https://jameschip.io/index.xml" class="rss">rss</a>
-				<img loading="lazy" src='https://jameschip.io/media/icons/jc88x31.gif' />
+				<img loading="lazy" src='https://jameschip.io/media/icons/jc88x31.gif' width="88" height="31">
 			</li>
 			<li data-lang="en" id="94">
 				<a href="https://patrick-is.cool">patrick-is.cool</a>
@@ -306,11 +306,11 @@
 			</li>
 			<li data-lang="en" id="101">
 				<a href="https://eti.tf">eti.tf</a>
-				<img loading="lazy" src="https://eti.tf/img/webring-banner.gif" alt="eti's webring banner"/>
+				<img loading="lazy" src="https://eti.tf/img/webring-banner.gif" alt="eti's webring banner" width="88" height="31">
 			</li>
 			<li data-lang="en" id="102">
 				<a href="https://rezmason.net">rezmason.net</a>
-				<img loading="lazy" src="https://www.rezmason.net/assets/button.gif" alt="rezmason's webring banner" />
+				<img loading="lazy" src="https://www.rezmason.net/assets/button.gif" alt="rezmason's webring banner" width="88" height="31">
 			</li>
 			<li data-lang="en cz" id="103">
 				<a href="https://estfyr.net">estfyr.net</a>
@@ -328,12 +328,12 @@
 			<li data-lang="en ita" id="109">
 				<a href="https://simone.computer">Simone's Computer</a>
 				<a href="https://system31.simone.computer/rss.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://system31.simone.computer/assets/88x31.gif">
+				<img loading="lazy" src="https://system31.simone.computer/assets/88x31.gif" width="88" height="31">
 			</li>
 			<li data-lang="en es eo" id="0x6c88354e70">
 				<a href="https://sunshinegardens.org/~xj9/">dreamspace</a>
 				<a href="https://sunshinegardens.org/~xj9/feed.atom" class="rss">rss</a>
-				<img loading="lazy" src="https://sunshinegardens.org/~xj9/activelink.gif" />
+				<img loading="lazy" src="https://sunshinegardens.org/~xj9/activelink.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="112">
 				<a href="http://q.pfiffer.org/">q.pfiffer.org</a>
@@ -341,7 +341,7 @@
 			</li>
 			<li data-lang="en" id="114">
 				<a href="https://zvava.org">zvava</a>
-				<img loading="lazy" src="https://zvava.org/images/buttons/zvava.org.png">
+				<img loading="lazy" src="https://zvava.org/images/buttons/zvava.org.png" width="88" height="31">
 			</li>
 			<li data-lang="en" id="115">
 				<a href="https://amorphic.space">amorphic.space</a>
@@ -408,7 +408,7 @@
 			</li>
 			<li data-lang="en" id="deianeira">
 				<a href="https://deianeira.co">deianeira.co</a>
-				<img loading="lazy" src="https://deianeira.co/res/88x31.gif">
+				<img loading="lazy" src="https://deianeira.co/res/88x31.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="133">
 				<a href="https://inqlab.net">inqlab.net</a>
@@ -423,7 +423,7 @@
 			<li data-lang="en" id="136">
 				<a href="https://metasyn.pw">metasyn</a>
 				<a href="https://metasyn.pw/rss.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://metasyn.pw/resources/img/mtsn.gif" />
+				<img loading="lazy" src="https://metasyn.pw/resources/img/mtsn.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="137">
 				<a href="https://www.milofultz.com">milofultz</a>
@@ -441,7 +441,7 @@
 			<li data-lang="en" id="141">
 				<a href="https://wolfmd.me">wolfmd</a>
 				<a href="https://wolfmd.me/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://wolfmd.me/img/banner.gif" alt="wolfmd webring banner"/>
+				<img loading="lazy" src="https://wolfmd.me/img/banner.gif" alt="wolfmd webring banner" width="88" height="31">
 			</li>
 			<li data-lang="en" id="143">
 				<a href="https://void.cc">automata / vilson vieira</a>
@@ -449,16 +449,16 @@
 			<li data-lang="en" id="144">
 				<a href="https://hecanjog.com">he can jog</a>
 				<a href="https://hecanjog.com/twtxt.txt" class="twtxt">twtxt</a>
-				<img loading="lazy" src="https://hecanjog.com/hcj-banner.gif"/>
+				<img loading="lazy" src="https://hecanjog.com/hcj-banner.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="145">
 				<a href="http://fragmentscenario.com/">fragmentscenario</a>
-				<img loading="lazy" src="http://www.fragmentscenario.com/img/frgmnt_webbanner.gif"/>
+				<img loading="lazy" src="http://www.fragmentscenario.com/img/frgmnt_webbanner.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="146">
 				<a href="https://corvid.cafe/">corvid cafe</a>
 				<a href="https://corvid.cafe/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src='https://corvid.cafe/images/icon.gif' />
+				<img loading="lazy" src='https://corvid.cafe/images/icon.gif' width="88" height="31">
 			</li>
 			<li data-lang="en" id="147">
 				<a href="https://aless.co">anti-pattern / alessia bellisario</a>
@@ -470,7 +470,7 @@
 			<li data-lang="en" id="150">
 				<a href="https://mrshll.com">mrshll</a>
 				<a href="https://mrshll.com/feed.rss" class="rss">rss</a>
-				<img loading="lazy" src='https://mrshll.com/img/mmx_button.gif' />
+				<img loading="lazy" src='https://mrshll.com/img/mmx_button.gif' width="88" height="31">
 			</li>
 			<li data-lang="en" id="151">
 				<a href="https://everest-pipkin.com/">everest pipkin</a>
@@ -482,7 +482,7 @@
 			<li data-lang="en" id="notebook.hew.tt">
 				<a href="https://notebook.hew.tt">notebook.hew.tt</a>
 				<a href="https://notebook.hew.tt/index.xml" class="rss">rss</a>
-				<img loading="lazy" src='https://notebook.hew.tt/animated-icon.gif' />
+				<img loading="lazy" src='https://notebook.hew.tt/animated-icon.gif' width="88" height="31">
 			</li>
 			<li data-lang="en" id="pbatch">
 				<a href="https://pbat.ch">pbatch</a>
@@ -491,7 +491,7 @@
 			<li data-lang="en" id="156">
 				<a href="https://dom.ink">dom</a>
 				<a href="https://dom.ink/tw.txt" class="twtxt">twtxt</a>
-				<img loading="lazy" src='https://dom.ink/img/button.gif' />
+				<img loading="lazy" src='https://dom.ink/img/button.gif' width="88" height="31">
 			</li>
 			<li data-lang="en" id="157">
 				<a href="https://njoqi.me">njoqi</a>
@@ -510,7 +510,7 @@
 			<li data-lang="en" id="tendigits">
 				<a href="https://tendigits.space">Ten Digits</a>
 				<a href="https://tendigits.space/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://tendigits.space/assets/tendigits-webring.gif">
+				<img loading="lazy" src="https://tendigits.space/assets/tendigits-webring.gif" width="88" height="31">
 			</li>
 			<li data-lang="en de" id="163">
 				<a href="https://sirtetris.com">sirtetris</a>
@@ -524,12 +524,12 @@
 			</li>
 			<li data-lang="en" id="bad10de">
 				<a href="https://badd10de.dev">badd10de</a>
-				<img loading="lazy" src="https://badd10de.dev/assets/webring_icn.gif" />
+				<img loading="lazy" src="https://badd10de.dev/assets/webring_icn.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="nilfm">
 				<a href="https://nilfm.cc">nilFM</a>
 				<a href="https://nilfm.cc/twtxt.txt" class="twtxt">twtxt</a>
-				<img loading="lazy" src="https://nilfm.cc/img/webring_banner.gif"/>
+				<img loading="lazy" src="https://nilfm.cc/img/webring_banner.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="wilde-at-heart">
 				<a href="https://wilde-at-heart.garden">wilde at heart</a>
@@ -540,7 +540,7 @@
 			<li data-lang="en" id="pixouls">
 				<a href="https://pixouls.xyz">pixouls</a>
 				<a href="https://www.pixouls.xyz/rss.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://www.pixouls.xyz/files/button.png" alt="pixouls.xyz webring banner" />
+				<img loading="lazy" src="https://www.pixouls.xyz/files/button.png" alt="pixouls.xyz webring banner" width="88" height="31">
 			</li>
 			<li data-lang="en" id="embyr">
 				<a href="https://embyr.sh"><i>embyr.sh</i></a>
@@ -556,13 +556,13 @@
 			</li>
 			<li data-lang="en" id="yhnck">
 				<a href="https://yhnck.xyz">yhancik</a>
-				<img loading="lazy" src="https://yhnck.xyz/button.gif"/>
+				<img loading="lazy" src="https://yhnck.xyz/button.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="astralbijection">
 				<a href="https://astrid.tech">astral&harr;bijection</a>
 				<a href="https://astrid.tech/tw.txt" class="twtxt">twtxt</a>
 				<a href="https://astrid.tech/atom.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://astrid.tech/banner-88x31.gif" />
+				<img loading="lazy" src="https://astrid.tech/banner-88x31.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="flower-codes">
 				<a href="http://flower.codes">flower.codes</a>
@@ -575,7 +575,9 @@
 					src="https://noelle.dev/assets/images/button.gif"
 					alt="noelle.dev webring banner"
 					style="image-rendering: pixelated;"
-				/>
+					width="88"
+					height="31"
+				>
 			</li>
 			<li data-lang="en" id="giacinto-carlucci">
 				<a href="https://www.giacintocarlucci.it">giacintocarlucci.it</a>
@@ -583,7 +585,7 @@
 			<li data-lang="en" id="paritybit">
 				<a href="https://www.paritybit.ca">paritybit.ca</a>
 				<a href="https://www.paritybit.ca/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://www.paritybit.ca/img/88x31icon.png" alt="paritybit.ca webring banner"/>
+				<img loading="lazy" src="https://www.paritybit.ca/img/88x31icon.png" alt="paritybit.ca webring banner" width="88" height="31">
 			</li>
 			<li data-lang="en" id="vladh">
 				<a href="https://vladh.net">vladh</a>
@@ -611,7 +613,7 @@
 			</li>
 			<li data-lang="en" id="detondev">
 				<a href="https://detondev.com">DetonDev</a>
-				<img loading="lazy" src='https://detondev.com/images/self/button.gif' />
+				<img loading="lazy" src='https://detondev.com/images/self/button.gif' width="88" height="31">
 			</li>
 			<li data-lang="en fr de" id="arcade">
 				<a href="https://arcades.agency">Aethopica</a>
@@ -622,7 +624,7 @@
 			<li data-lang="en" id="helveticablanc">
 				<a href="https://helveticablanc.com/">Helvetica Blanc</a>
 				<a href="https://helveticablanc.com/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://helveticablanc.com/img/button.gif"/>
+				<img loading="lazy" src="https://helveticablanc.com/img/button.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="colindrake">
 				<a href="https://colindrake.me">colindrake.me</a>
@@ -633,14 +635,14 @@
 			<li data-lang="en" id="armaina">
 				<a href="http://armaina.com/">armaina</a>
 				<a href="http://armaina.com/rss.xml" class="rss">rss</a>
-				<img loading="lazy" src="http://armaina.com/88x31.jpg"/>
+				<img loading="lazy" src="http://armaina.com/88x31.jpg" width="88" height="31">
 			</li>
 			<li data-lang="en" id="sindhulive">
 				<a href="https://sindhu.live">sindhu.live</a>
 			</li>
 			<li data-lang="en" id="nuel">
 				<a href="https://nuel.pw">nuel</a>
-				<img loading="lazy" src="https://nuel.pw/button.gif"/>
+				<img loading="lazy" src="https://nuel.pw/button.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="ffsanton">
 				<a href="https://ffs.fm">ffs.fm</a>
@@ -648,7 +650,7 @@
 			<li data-lang="en" id="aphrodite.dev">
 				<a href="https://www.aphrodite.dev/">aphrodite.dev</a>
 				<a href="https://www.aphrodite.dev/~blog/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://www.aphrodite.dev/badge.gif"/>
+				<img loading="lazy" src="https://www.aphrodite.dev/badge.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="zealco">
 				<a href="https://zeal.co">zeal.co</a>
@@ -656,7 +658,7 @@
 			<li data-lang="en" id="nataziel.nexus">
 				<a href="https://nataziel.nexus">nataziel.nexus</a>
 				<a href="https://nataziel.nexus/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://nataziel.nexus/static/icons/wyrm.svg"/>
+				<img loading="lazy" src="https://nataziel.nexus/static/icons/wyrm.svg" width="88" height="31">
 			</li>
 			<li data-lang="en" id="canalswans">
 				<a href="https://canalswans.commoninternet.net">canalswans</a>
@@ -664,7 +666,7 @@
 			<li data-lang="en" id="erin">
 				<a href="https://erinbern.com">Erin Bern</a>
 				<a href="https://erinbern.com/feed" class="rss">rss</a>
-				<img loading="lazy" src='https://bear-images.sfo2.cdn.digitaloceanspaces.com/erinbern-1666689915-0.png' />
+				<img loading="lazy" src='https://bear-images.sfo2.cdn.digitaloceanspaces.com/erinbern-1666689915-0.png' width="88" height="31">
 			</li>
 			<li data-lang="en" id="kira">
 				<a href="http://kira.eight45.net">Kira's Web-Treehouse</a>
@@ -720,7 +722,7 @@
 				<a href="https://benji.dog">benji</a>
 				<a href="https://benji.dog/twtxt.txt" class="twtxt">twtxt</a>
 				<a href="https://benji.dog/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://benji.dog/assets/88x31.png"/>
+				<img loading="lazy" src="https://benji.dog/assets/88x31.png" width="88" height="31">
 			</li>
 			<li data-lang="en" id="manifoldslug">
 				<a href="http://wreckage.link">manifoldslug</a>
@@ -736,7 +738,7 @@
 			<li data-lang="en" id="foreverlikethis">
 				<a href="https://foreverliketh.is/">foreverliketh.is</a>
 				<a href="https://foreverliketh.is/blog/index.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://foreverliketh.is/docs/connectivism/home-page/buttons/foreverliketh.is.png"/>
+				<img loading="lazy" src="https://foreverliketh.is/docs/connectivism/home-page/buttons/foreverliketh.is.png" width="88" height="31">
 			</li>
 			<li data-lang="en" id="monoxane">
 				<a href="https://monoxane.io">monoxane</a>
@@ -810,7 +812,7 @@
 			<li data-lang="en" id="beespace">
 				<a href="https://lunabee.space/extraspace/port.html">beespace</a>
 				<a href="https://lunabee.space/beespace.atom" class="rss">rss</a>
-				<img loading="lazy" src="https://lunabee.space/8831.gif"/>
+				<img loading="lazy" src="https://lunabee.space/8831.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="jakintosh">
 				<a href="http://jakintosh.com">jakintosh.com</a>
@@ -832,7 +834,7 @@
 				Found a broken link, please <a href="https://github.com/XXIIVV/webring/issues/new" target="_blank">report it</a>.<br /><br />
 				<a href="#icons">Show icons</a> | <a href="#twtxt">Show twtxt</a> | <a href="#rss">Show rss</a><span class="hide"> | <a href="#">Hide Feeds</a></span> | <a href="https://lieu.cblgh.org/random" target="_blank">Random</a>
 			</p>
-			<img id="icon" src="icon.black.large.svg" alt="icon"/>
+			<img id="icon" src="icon.black.large.svg" alt="icon" width="300" height="300">
 		</footer>
 		<style>
 			:root { --color-alpha: white; --color-beta: black; }
@@ -843,13 +845,13 @@
 			body a:after { content: '}'; }
 			body > ol { margin: 30px; padding: 0px 30px 30px; column-count: 3; display: block; border-bottom: 2px solid var(--color-beta); }
 			body > ol > li { padding-right: 30px; }
-			body > ol > li img { display: none; margin:5px; max-width: 88px }
+			body > ol > li img { display: none; margin:5px; max-width: 88px; height: auto; }
 			body > ol > li a.rss, body > ol > li a.twtxt { display: none; }
 			body > ol > li a:visited:before, body > ol > li a:visited:after { color: var(--color-alpha); }
 			body > footer { margin: 30px; }
 			body > footer > p { max-width: 600px; }
 			body > footer > p span.hide { display: none; }
-			body > footer > img { display: inline-block; width: 100px; margin-bottom: -5px; margin-bottom: 30px; }
+			body > footer > img { display: inline-block; width: 100px; height: auto; margin-bottom: -5px; margin-bottom: 30px; }
 			body:target > ol li a.twtxt, html:target li a.rss { background: var(--color-beta); color: var(--color-alpha); display: inline; }
 			body:target > footer > p > span.hide, html:target footer > p > span.hide { display: inline; }
 			body > ol:target > li > img { display:block; }


### PR DESCRIPTION
When toggling the visibility of the icons, the list items shift around a bunch as all the images are loaded. By specifying the `width` and `height` of the images, the browser can adjust the layout instantly before they are even loaded, eliminating the reflows.

Also set `overflow: hidden` on the images so that the alt text that appears when the image won't load doesn't trigger a reflow.

Also updated the examples in the README to include `width`, `height`, and `alt`.