### PR TITLE
Remove duplicate entry for beespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -826,11 +826,6 @@
       <li lang="en" id="slewis">
         <a href="https://slewis.wiki/">slewis.wiki</a>
       </li>
-      <li data-lang="en" id="beespace">
-        <a href="https://lunabee.space/extraspace/port.html">beespace</a>
-        <a href="https://lunabee.space/beespace.atom" class="rss">rss</a>
-        <img loading="lazy" src="https://lunabee.space/8831.gif"/>
-      </li>
 			<li data-lang="en" id="drawkcab">
 				<a href="https://www.drawk.cab/">drawk.cab</a>
 			</li>


### PR DESCRIPTION
Somehow commit 8e822d6 added [beespace](https://lunabee.space/extraspace/port.html) for a second time (originally added in 2fa96ab). This PR removes the second instance.