### PR TITLE
Add 22h49.one to the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -823,22 +823,33 @@
 			<li data-lang="en" id="dziban">
 				<a href="https://dziban.net">Dziban</a>
 			</li>
-      <li lang="en" id="slewis">
-        <a href="https://slewis.wiki/">slewis.wiki</a>
-      </li>
+			<li lang="en" id="slewis">
+				<a href="https://slewis.wiki/">slewis.wiki</a>
+			</li>
 			<li data-lang="en" id="drawkcab">
 				<a href="https://www.drawk.cab/">drawk.cab</a>
 			</li>
-      <li lang="en" id="knights">
-        <a href="https://guerrero.ph">guerrero.ph</a>
-      </li>
-      <li data-lang="en" id="plantay">
+			<li lang="en" id="knights">
+				<a href="https://guerrero.ph">guerrero.ph</a>
+			</li>
+			<li data-lang="en" id="plantay">
 				<a href="https://plantay.me">Plantay</a>
 			</li>
-      <li data-lang="en" id="alexeystar">
+			<li data-lang="en" id="alexeystar">
 				<a href="https://alexeystar.com/">alexeystar.com</a>
 				<a href="https://www.alexeystar.com/index.xml" class="rss">rss</a>
-      </li>
+			</li>
+			<li data-lang="en" id="22h49">
+				<a href="https://22h49.one">22h49</a>
+				<a href="https://22h49.one/zine/atom.xml" class="rss">rss</a>
+				<img
+					loading="lazy"
+					src="https://22h49.one/images/button.gif"
+					alt="22h49 button"
+					width="88"
+					height="31"
+				>
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
Hi!

I want to propose my website for the webring.

Just a disclaimer since I know the person reviewing this probably lives on a boat, loading all pages (excluding the photos from the portfolio and git diffs) will take up about 6.5 MB of bandwith without compression, and ~4MB with brotli. The site makes moderate use of various visuals (and gifs).

The logo and circular links are at the bottom of [this site](https://22h49.one/table/).

I've taken the liberty of normalizing the indentation in the `index.html` file. Some of the newer entries were space indented whist the rest was tabs.

Thanks!