### PR TITLE
li shouldnt split between columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,646 +3,646 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="con" type="image/png" sizes="100x100" href="favicon.ico">
-    <link rel="apple-touch-icon" type="image/png" sizes="100x100" href="favicon.ico">
+    <link rel="con" type="image/png" sizes="100x100" href="favicon.ico"><span>
+    <link rel="apple-touch-icon" type="image/png" sizes="100x100" href="favicon.ico"><span>
     <title>Webring</title>
   </head>
   <body id="twtxt">
     <ol id="icons">
-      <li data-lang="en" id="xxiivv">
+      <li data-lang="en" id="xxiivv"><span>
         <a href="https://wiki.xxiivv.com">xxiivv</a>
         <a href="https://wiki.xxiivv.com/links/tw.txt" class="twtxt">twtxt</a>
         <a href="https://wiki.xxiivv.com/links/rss.xml" class="rss">rss</a>
         <img src='https://wiki.xxiivv.com/media/services/button.gif' />
-      </li>
-      <li data-lang="en" id="1">
+      </span></li>
+      <li data-lang="en" id="1"><span>
         <a href="http://estevancarlos.com">estevancarlos</a>
-      </li>
-      <li data-lang="en" id="2">
+      </span></li>
+      <li data-lang="en" id="2"><span>
         <a href="https://electro.pizza">electro pizza</a>
         <a href="https://electro.pizza/twtxt.txt" class="twtxt">twtxt</a>
         <a href="https://electro.pizza/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="3">
+      </span></li>
+      <li data-lang="en" id="3"><span>
         <a href="https://avanier.studio">Arachne</a>
         <a href="https://avanier.studio/tw.txt" class="twtxt">twtxt</a>
         <img src='https://avanier.studio/m/88x31.gif' />
-      </li>
-      <li data-lang="en" id="4">
+      </span></li>
+      <li data-lang="en" id="4"><span>
         <a href="https://kaemura.com">kaemura</a>
         <a href="https://kaemura.com/twttxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="5">
+      </span></li>
+      <li data-lang="en" id="5"><span>
         <a href="https://bismuth.garden">bismuth.garden</a>
         <a href="https://bismuth.garden/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="6">
+      </span></li>
+      <li data-lang="en" id="6"><span>
         <a href="https://hraew.autophagy.io">hraew.autophagy</a>
-      </li>
-      <li data-lang="en" id="8">
+      </span></li>
+      <li data-lang="en" id="8"><span>
         <a href="https://anxl.faith">anxl.faith</a>
-      </li>
-      <li data-lang="fr" id="9">
+      </span></li>
+      <li data-lang="fr" id="9"><span>
         <a href="https://xvw.github.io">planet</a>
         <a href="https://xvw.github.io/twtxt/hallway.txt" class="twtxt">twtxt</a>
         <a href="https://xvw.github.io/atom.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en el" id="10">
+      </span></li>
+      <li data-lang="en el" id="10"><span>
         <a href="https://heracl.es">heracl.es</a>
-      </li>
-      <li data-lang="en" id="11">
+      </span></li>
+      <li data-lang="en" id="11"><span>
         <a href="https://stecko.website">stecko.website</a>
-      </li>
-      <li data-lang="en" id="12">
+      </span></li>
+      <li data-lang="en" id="12"><span>
         <a href="https://now.lectronice.com">lectronice</a>
         <a href="https://now.lectronice.com/feed.xml" class="rss">rss</a>
         <img src="https://now.lectronice.com/lctrncbttn.gif" />
-      </li>
-      <li data-lang="en" id="13">
+      </span></li>
+      <li data-lang="en" id="13"><span>
         <a href="https://craze.co.uk">craze.co.uk</a>
-      </li>
-      <li data-lang="en" id="14">
+      </span></li>
+      <li data-lang="en" id="14"><span>
         <a href="https://shaneckel.com">shaneckel</a>
-      </li>
-      <li data-lang="en" id="15">
+      </span></li>
+      <li data-lang="en" id="15"><span>
         <a href="https://cblgh.org">cblgh</a>
         <a href="https://cblgh.org/twtxt.txt" class="twtxt">twtxt</a>
         <img src="https://cblgh.org/dl/cblgh-webring.gif" alt="cblgh.org webring banner">
-      </li>
-      <li data-lang="en" id="16">
+      </span></li>
+      <li data-lang="en" id="16"><span>
         <a href="https://ellugar.co">ellugar</a>
         <a href="http://feeds.ellugar.co/ellugar-logs" class="rss">rss</a>
         <img src="https://ellugar.co/img/button.gif" alt="ellugar.co banner">
-      </li>
-      <li data-lang="en" id="17">
+      </span></li>
+      <li data-lang="en" id="17"><span>
         <a href="http://chigby.org">chigby</a>
-      </li>
-      <li data-lang="en" id="18">
+      </span></li>
+      <li data-lang="en" id="18"><span>
         <a href="https://longest.voyage">longest.voyage</a>
         <a href="https://longest.voyage/index.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="19">
+      </span></li>
+      <li data-lang="en" id="19"><span>
         <a href="https://palomakop.tv">palomakop.tv</a>
-      </li>
-      <li data-lang="en" id="20">
+      </span></li>
+      <li data-lang="en" id="20"><span>
         <a href="https://v-os.ca">v-os.ca</a>
-      </li>
-      <li data-lang="en" id="21">
+      </span></li>
+      <li data-lang="en" id="21"><span>
         <a href="https://jmandel.xyz">jmandel.xyz</a>
-      </li>
-      <li data-lang="en" id="22">
+      </span></li>
+      <li data-lang="en" id="22"><span>
         <a href="https://2d4.dev">2d4.dev</a>
         <a href="https://2d4.dev/tw.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="23">
+      </span></li>
+      <li data-lang="en" id="23"><span>
         <a href="https://nathanwentworth.co">nathanwentworth</a>
-      </li>
-      <li data-lang="en" id="24">
+      </span></li>
+      <li data-lang="en" id="24"><span>
         <a href="https://uonai.space">uonai.space</a>
-      </li>
-      <li data-lang="en" id="25">
+      </span></li>
+      <li data-lang="en" id="25"><span>
         <a href="http://controls.ee">controls.ee</a>
-      </li>
-      <li data-lang="en" id="26">
+      </span></li>
+      <li data-lang="en" id="26"><span>
         <a href="https://wasin.io">wasin</a>
-      </li>
-      <li data-lang="en" id="27">
+      </span></li>
+      <li data-lang="en" id="27"><span>
         <a href="https://inns.studio">inns.studio</a>
-      </li>
-      <li data-lang="en" id="28">
+      </span></li>
+      <li data-lang="en" id="28"><span>
         <a href="http://kokorobot.ca">kokorobot.ca</a>
         <img src="https://kokorobot.ca/media/interface/button.gif" alt="kokorobot"/>
         <a href="https://kokorobot.ca/links/rss.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="29">
+      </span></li>
+      <li data-lang="en" id="29"><span>
         <a href="https://ameyama.com">ameyama</a>
         <a href="https://ameyama.com/blog/rss.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="30">
+      </span></li>
+      <li data-lang="en" id="30"><span>
         <a href="https://wake.st">wake.st</a>
         <a href="https://wake.st/twtxt.txt" class="twtxt">twtxt</a>
         <img src="https://wake.st/webring/banner.gif" alt="wake.st webring banner">
-      </li>
-      <li data-lang="en" id="31">
+      </span></li>
+      <li data-lang="en" id="31"><span>
         <a href="https://xarene.la">xarene.la</a>
-      </li>
-      <li data-lang="en" id="32">
+      </span></li>
+      <li data-lang="en" id="32"><span>
         <a href="https://alex.zyzhang.me">alex.zyzhang.me</a>
-      </li>
-      <li data-lang="en" id="33">
+      </span></li>
+      <li data-lang="en" id="33"><span>
         <a href="http://bildwissenschaft.vortok.info">vortok</a>
-      </li>
-      <li data-lang="en" id="35">
+      </span></li>
+      <li data-lang="en" id="35"><span>
         <a href="https://aeriform.io">aeriform.io</a>
-      </li>
-      <li data-lang="en" id="37">
+      </span></li>
+      <li data-lang="en" id="37"><span>
         <a href="http://nonmateria.com">nonmateria</a>
         <a href="http://nonmateria.com/rss.xml" class="rss">rss</a>
         <img src="http://nonmateria.com/data/avatars/banner.gif" alt="nonmateria.com webring banner">
-      </li>
-      <li data-lang="en" id="38">
+      </span></li>
+      <li data-lang="en" id="38"><span>
         <a href="https://underscorediscovery.ca">underscorediscovery</a>
-      </li>
-      <li data-lang="en" id="39">
+      </span></li>
+      <li data-lang="en" id="39"><span>
         <a href="https://drisc.io">drisc</a>
         <a href="https://drisc.io/hallway/twtxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="40">
+      </span></li>
+      <li data-lang="en" id="40"><span>
         <a href="https://ricky.codes">ricky.codes</a>
-      </li>
-      <li data-lang="en" id="41">
+      </span></li>
+      <li data-lang="en" id="41"><span>
         <a href="https://maxdeviant.com">maxdeviant</a>
-      </li>
-      <li data-lang="en" id="42">
+      </span></li>
+      <li data-lang="en" id="42"><span>
         <a href="https://tynandebold.com">tynandebold</a>
-      </li>
-      <li data-lang="en" id="43">
+      </span></li>
+      <li data-lang="en" id="43"><span>
         <a href="http://gytis.co">gytis.co</a>
-      </li>
-      <li data-lang="en" id="44">
+      </span></li>
+      <li data-lang="en" id="44"><span>
         <a href="https://nomand.co">nomand.co</a>
-      </li>
-      <li data-lang="en" id="45">
+      </span></li>
+      <li data-lang="en" id="45"><span>
         <a href="http://memoriata.com">memoriata</a>
-      </li>
-      <li data-lang="en" id="46">
+      </span></li>
+      <li data-lang="en" id="46"><span>
         <a href="https://mmm.s-ol.nu">s-ol.nu</a>
-      </li>
-      <li data-lang="en" id="47">
+      </span></li>
+      <li data-lang="en" id="47"><span>
         <a href="https://chad.is">chad.is</a>
         <a href="https://chad.is/rss.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="48">
+      </span></li>
+      <li data-lang="en" id="48"><span>
         <a href="https://smidgeo.com/bots">smidgeo.com/bots</a>
-      </li>
-      <li data-lang="en ru" id="49">
+      </span></li>
+      <li data-lang="en ru" id="49"><span>
         <a href="https://iko.soy">iko.soy</a>
-      </li>
-      <li data-lang="en" id="50">
+      </span></li>
+      <li data-lang="en" id="50"><span>
         <a href="https://ritualdust.com">ritual dust</a>
         <a href="https://ritualdust.com/index.xml" class="rss">rss</a>
         <img src="https://ritualdust.com/img/button.gif" />
-      </li>
-      <li data-lang="en" id="51">
+      </span></li>
+      <li data-lang="en" id="51"><span>
         <a href="https://magoz.is">magoz.is</a>
-      </li>
-      <li data-lang="en" id="52">
+      </span></li>
+      <li data-lang="en" id="52"><span>
         <a href="https://szymonkaliski.com">szymonkaliski</a>
         <a href="https://szymonkaliski.com/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="53">
+      </span></li>
+      <li data-lang="en" id="53"><span>
         <a href="https://phse.net">phse.net</a>
         <a href="https://phse.net/twtxt/merv.txt" class="twtxt">twtxt</a>
         <a href="https://phse.net/post/index.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="54">
+      </span></li>
+      <li data-lang="en" id="54"><span>
         <a href="https://rosano.ca">rosano.ca</a>
         <a href="https://rosano.ca/feed" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="56">
+      </span></li>
+      <li data-lang="en" id="56"><span>
         <a href="https://gndclouds.cc">gndclouds.cc</a>
-      </li>
-      <li data-lang="en fr" id="57">
+      </span></li>
+      <li data-lang="en fr" id="57"><span>
         <a href="https://xuv.be">xuv.be</a>
-      </li>
-      <li data-lang="en zh" id="58">
+      </span></li>
+      <li data-lang="en zh" id="58"><span>
         <a href="https://dsdshcym.github.io">dsdshcym.github.io</a>
-      </li>
-      <li data-lang="en" id="60">
+      </span></li>
+      <li data-lang="en" id="60"><span>
         <a href="https://boffosocko.com">boffosocko</a>
-      </li>
-      <li data-lang="en" id="61">
+      </span></li>
+      <li data-lang="en" id="61"><span>
         <a href="https://hex22.org">hex22</a>
         <a href="https://t.seed.hex22.org/twtxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="62">
+      </span></li>
+      <li data-lang="en" id="62"><span>
         <a href="https://patrikarvidsson.com">patrikarvidsson</a>
-      </li>
-      <li data-lang="en" id="63">
+      </span></li>
+      <li data-lang="en" id="63"><span>
         <a href="https://sophieleetmaa.com">sophieleetmaa</a>
-      </li>
-      <li data-lang="en" id="64">
+      </span></li>
+      <li data-lang="en" id="64"><span>
         <a href="https://xinniw.github.io">xinniw.github</a>
-      </li>
-      <li data-lang="en" id="65">
+      </span></li>
+      <li data-lang="en" id="65"><span>
         <a href="https://mboxed.github.io/sodatsu">sodatsu</a>
         <a href="https://mboxed.github.io/sodatsu/tw.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="66">
+      </span></li>
+      <li data-lang="en" id="66"><span>
         <a href="https://letters.vexingworkshop.com">vexingworkshop</a>
-      </li>
-      <li data-lang="en" id="67">
+      </span></li>
+      <li data-lang="en" id="67"><span>
         <a href="https://tom.so">tom hackshaw</a>
-      </li>
-      <li data-lang="en" id="68">
+      </span></li>
+      <li data-lang="en" id="68"><span>
         <a href="https://teknari.com">Teknari</a>
         <a href="https://teknari.com/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="es" id="69">
+      </span></li>
+      <li data-lang="es" id="69"><span>
         <a href="https://colectivo-de-livecoders.gitlab.io">Colectivo de Livecoders</a>
-      </li>
-      <li data-lang="es" id="70">
+      </span></li>
+      <li data-lang="es" id="70"><span>
         <a href="https://www.madewithtea.com">madewithtea</a>
-      </li>
-      <li data-lang="en" id="72">
+      </span></li>
+      <li data-lang="en" id="72"><span>
         <a href="http://www.miha-co.ca">miha-co</a>
-      </li>
-      <li data-lang="en" id="73">
+      </span></li>
+      <li data-lang="en" id="73"><span>
         <a href="https://buzzert.net">buzzert.net</a>
-      </li>
-      <li data-lang="en" id="75">
+      </span></li>
+      <li data-lang="en" id="75"><span>
         <a href="https://xxiii.co">xxiii</a>
         <a href="https://serocell.com/feeds/serocell.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="76">
+      </span></li>
+      <li data-lang="en" id="76"><span>
         <a href="https://kor.nz">kor</a>
         <a href="https://kor.nz/twtxt.txt" class="twtxt">twtxt</a>
         <img src="https://kor.nz/asset/button.gif" />
-      </li>
-      <li data-lang="en" id="77">
+      </span></li>
+      <li data-lang="en" id="77"><span>
         <a href="https://lublin.se">lublin.se</a>
         <a href="https://lublin.se/twtxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="78">
+      </span></li>
+      <li data-lang="en" id="78"><span>
         <a href="https://zanneth.com">zanneth</a>
-      </li>
-      <li data-lang="en" id="79">
+      </span></li>
+      <li data-lang="en" id="79"><span>
         <a href="https://eli.li">eli.li</a>
         <a href="https://txt.eli.li/twtxt/twtxt.txt" class="twtxt">twtxt</a>
         <a href="https://eli.li/feed.rss" class="rss">rss</a>
         <img src="https://txt.eli.li/pb/unicorn-barf.gif" alt="rainbow gradient">
-      </li>
-      <li data-lang="en" id="80">
+      </span></li>
+      <li data-lang="en" id="80"><span>
         <a href="https://gosha.net">Gosha</a>
         <a href="https://gosha.net/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="81">
+      </span></li>
+      <li data-lang="en" id="81"><span>
         <a href="https://www.tatecarson.com">Tate Carson</a>
-      </li>
-      <li data-lang="en" id="82">
+      </span></li>
+      <li data-lang="en" id="82"><span>
         <a href="https://azlen.me">azlen.me</a>
         <a href="https://azlen.me/twtxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="83">
+      </span></li>
+      <li data-lang="en" id="83"><span>
         <a href="https://opguides.info">OpGuides</a>
         <img src="https://opguides.info/opguides3.gif" alt="gradient hue shift">
-      </li>
-      <li data-lang="en" id="84">
+      </span></li>
+      <li data-lang="en" id="84"><span>
         <a href="https://chrismaughan.com/">CMaughan</a>
         <a href="https://chrismaughan.com/twtxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en it" id="85">
+      </span></li>
+      <li data-lang="en it" id="85"><span>
         <a href="https://oddworlds.org">oddworlds soliloquy</a>
         <a href="https://oddworlds.org/rss.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="86">
+      </span></li>
+      <li data-lang="en" id="86"><span>
         <a href="https://fundor333.com/">Fundor333</a>
         <a href="https://fundor333.com/twtxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="87">
+      </span></li>
+      <li data-lang="en" id="87"><span>
         <a href="https://cass.si">cass.si</a>
-      </li>
-      <li data-lang="en" id="88">
+      </span></li>
+      <li data-lang="en" id="88"><span>
         <a href="https://dotcomboom.somnolescent.net/">somnolescent.net</a>
         <a href="https://dotcomboom.somnolescent.net/twtxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="89">
+      </span></li>
+      <li data-lang="en" id="89"><span>
         <a href="https://cadmican.neocities.org/">cadmican</a>
-      </li>
-      <li data-lang="en" id="90">
+      </span></li>
+      <li data-lang="en" id="90"><span>
         <a href="https://resevoir.net">resevoir</a>
         <a href="https://resevoir.net/rss.xml" class="rss">rss</a>
         <img src="https://resevoir.net/images/button.gif" />
-      </li>
-      <li data-lang="en" id="91">
+      </span></li>
+      <li data-lang="en" id="91"><span>
         <a href="https://sixey.es/">sixey.es</a>
         <a href="https://sixey.es/feed.xml" class="rss">rss</a>
         <img src="https://sixey.es/6e20ass/8831.gif" />
-      </li>
-      <li data-lang="en" id="92">
+      </span></li>
+      <li data-lang="en" id="92"><span>
         <a href="https://0xdstn.site/">0xdstn</a>
         <a href="https://0xdstn.site/index.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="93">
+      </span></li>
+      <li data-lang="en" id="93"><span>
         <a href="http://www.jameschip.io">James Chip</a>
         <a href="http://www.jameschip.io/index.xml" class="rss">rss</a>
         <img src='http://www.jameschip.io/media/jc88x31.gif' />
-      </li>
-      <li data-lang="en" id="94">
+      </span></li>
+      <li data-lang="en" id="94"><span>
         <a href="https://patrick-is.cool">patrick-is.cool</a>
-      </li>
-      <li data-lang="en" id="95">
+      </span></li>
+      <li data-lang="en" id="95"><span>
         <a href="https://icyphox.sh">icyphox.sh</a>
         <a href="https://icyphox.sh/blog/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="96">
+      </span></li>
+      <li data-lang="en" id="96"><span>
         <a href="https://royniang.com">royniang.com</a>
         <a href="https://royniang.com/tw.txt" class="twtxt">twtxt</a>
         <a href="https://royniang.com/rss.xml" class="rss">rss</a>
         <img src='https://royniang.com/media/identity/banner.png' />
-      </li>
-      <li data-lang="en" id="97">
+      </span></li>
+      <li data-lang="en" id="97"><span>
         <a href="https://www.raul.earth/">raul altosaar</a>
-      </li>
-      <li data-lang="en" id="98">
+      </span></li>
+      <li data-lang="en" id="98"><span>
         <a href="https://crlf.link">Cr;Lf;</a>
         <a href="https://crlf.link/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="99">
+      </span></li>
+      <li data-lang="en" id="99"><span>
         <a href="https://www.johannesg.com">Jóhannes G. Þorsteinsson</a>
-      </li>
-      <li data-lang="en" id="100">
+      </span></li>
+      <li data-lang="en" id="100"><span>
         <a href="https://provokeanalog.com">Provoke Analog</a>
-      </li>
-      <li data-lang="en" id="101">
+      </span></li>
+      <li data-lang="en" id="101"><span>
         <a href="https://eti.tf">eti.tf</a>
         <img alt="eti's webring banner" src="https://eti.tf/img/webring-banner.gif" />
-      </li>
-      <li data-lang="en" id="102">
+      </span></li>
+      <li data-lang="en" id="102"><span>
         <a href="https://rezmason.net">rezmason.net</a>
         <img alt="rezmason's webring banner" src="https://www.rezmason.net/assets/button.gif" />
-      </li>
-      <li data-lang="en cz" id="103">
+      </span></li>
+      <li data-lang="en cz" id="103"><span>
         <a href="https://estfyr.net">estfyr.net</a>
-      </li>
-      <li data-lang="en" id="104">
+      </span></li>
+      <li data-lang="en" id="104"><span>
         <a href="https://paysonwallach.com">paysonwallach.com</a>
-      </li>
-      <li data-lang="en" id="105">
+      </span></li>
+      <li data-lang="en" id="105"><span>
         <a href="https://natwelch.com">Nat Welch</a>
         <a href="https://writing.natwelch.com/feed.rss" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="106">
+      </span></li>
+      <li data-lang="en" id="106"><span>
         <a href="https://parkimminent.com">Park Imminent</a>
-      </li>
-      <li data-lang="en" id="107">
+      </span></li>
+      <li data-lang="en" id="107"><span>
         <a href="https://aklsh.now.sh">aklsh</a>
-      </li>
-      <li data-lang="en" id="108">
+      </span></li>
+      <li data-lang="en" id="108"><span>
         <a href="https://0xff.nu">Paul Glushak</a>
         <a href="https://0xff.nu/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en ita" id="109">
+      </span></li>
+      <li data-lang="en ita" id="109"><span>
         <a href="https://simone.computer">Simone's Computer</a>
         <a href="https://system32.simone.computer/rss.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en es" id="0x6F">
+      </span></li>
+      <li data-lang="en es" id="0x6F"><span>
         <a href="https://xj-ix.luxe">dreamspace</a>
         <a href="https://xj-ix.luxe/.well-known/twtxt/xjix.txt" class="twtxt">twtxt</a>
         <a href="https://xj-ix.luxe/feed.atom" class="rss">rss</a>
         <img src="https://xj-ix.luxe/activelink.gif" />
-      </li>
-      <li data-lang="en" id="111">
+      </span></li>
+      <li data-lang="en" id="111"><span>
         <a href="https://simply.personal.jenett.org">jenett. simply. personal.</a>
         <a href="https://simply.personal.jenett.org/feed" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="112">
+      </span></li>
+      <li data-lang="en" id="112"><span>
         <a href="http://q.pfiffer.org/">q.pfiffer.org</a>
         <a href="http://q.pfiffer.org/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="114">
+      </span></li>
+      <li data-lang="en" id="114"><span>
         <a href="https://zvava.org">zvava</a>
-      </li>
-      <li data-lang="en" id="115">
+      </span></li>
+      <li data-lang="en" id="115"><span>
         <a href="https://amorphic.space">amorphic.space</a>
-      </li>
-      <li data-lang="en nl" id="116">
+      </span></li>
+      <li data-lang="en nl" id="116"><span>
         <a href="https://www.edwinwenink.xyz">Archive Fever</a>
         <a href="https://www.edwinwenink.xyz/index.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en fr" id="117">
+      </span></li>
+      <li data-lang="en fr" id="117"><span>
         <a href="https://www.mentalnodes.com">Mental Nodes</a>
         <a href="https://www.mentalnodes.com/sitemap.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="es" id="118">
+      </span></li>
+      <li data-lang="es" id="118"><span>
         <a href="https://copiona.com">copiona</a>
-      </li>
-      <li data-lang="en nl" id="119">
+      </span></li>
+      <li data-lang="en nl" id="119"><span>
         <a href="https://proycon.anaproy.nl">proycon</a>
-      </li>
-      <li data-lang="en" id="120">
+      </span></li>
+      <li data-lang="en" id="120"><span>
         <a href="https://www.marginchronicles.com">margin chronicles</a>
-      </li>
-      <li data-lang="en" id="121">
+      </span></li>
+      <li data-lang="en" id="121"><span>
         <a href="https://roytang.net">roytang.net</a>
         <a href="https://roytang.net/index.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="122">
+      </span></li>
+      <li data-lang="en" id="122"><span>
         <a href="https://materialfuture.net">MaterialFuture</a>
         <a href="https://www.materialfuture.net/rss.xml" class="rss">rss</a>
-      </li>
-        <li data-lang="en" id="123">
+      </span></li>
+        <li data-lang="en" id="123"><span>
         <a href="https://solquemal.com/">solquemal</a>
-      </li>
-      <li data-lang="en" id="dampfkraft">
+      </span></li>
+      <li data-lang="en" id="dampfkraft"><span>
         <a href="https://dampfkraft.com">Dampfkraft</a>
         <a href="https://dampfkraft.com/index.rss" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="125">
+      </span></li>
+      <li data-lang="en" id="125"><span>
         <a href="https://travisshears.com">travisshears</a>
         <a href="https://travisshears.com/apps/twtxt/twtxt.txt" class="twtxt">twtxt</a>
         <a href="https://travisshears.com/index.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="126">
+      </span></li>
+      <li data-lang="en" id="126"><span>
         <a href="https://awalvie.me">awalvie</a>
-      </li>
-      <li data-lang="en ru" id="futuristan">
+      </span></li>
+      <li data-lang="en ru" id="futuristan"><span>
         <a href="https://futuristan.io">futuristan.io</a>
-      </li>
-      <li data-lang="en" id="romain aubert">
+      </span></li>
+      <li data-lang="en" id="romain aubert"><span>
         <a href="https://www.romainaubert.com/">romain aubert</a>
         <a href="https://www.romainaubert.com/twtxt.txt" class="twtxt">twtxt</a>
         <a href="https://www.romainaubert.com/feed.rss" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="ix5">
+      </span></li>
+      <li data-lang="en" id="ix5"><span>
         <a href="https://ix5.org/">Felix Elsner</a>
         <a href="https://ix5.org/thoughts/feeds/all.atom.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="128">
+      </span></li>
+      <li data-lang="en" id="128"><span>
         <a href="https://www.juliendesrosiers.com/">Julien Desrosiers</a>
         <a href="https://www.juliendesrosiers.com/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="129">
+      </span></li>
+      <li data-lang="en" id="129"><span>
         <a href="https://nchrs.xyz">nchrs.xyz</a>
         <a href="https://nchrs.xyz/rss.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="northerinformation">
+      </span></li>
+      <li data-lang="en" id="northerinformation"><span>
         <a href="https://nor.the-rn.info">Northern Information</a>
         <a href="https://nor.the-rn.info/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="131">
+      </span></li>
+      <li data-lang="en" id="131"><span>
         <a href="https://matildepark.ca">Matilde Park</a>
         <a href="https://matildepark.ca/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="132">
+      </span></li>
+      <li data-lang="en" id="132"><span>
         <a href="https://fdisk.space">ƒdisk.space</a>
         <a href="https://fdisk.space/rss.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="deianeira">
+      </span></li>
+      <li data-lang="en" id="deianeira"><span>
         <a href="https://deianeira.co">deianeira.co</a>
-      </li>
-      <li data-lang="en" id="133">
+      </span></li>
+      <li data-lang="en" id="133"><span>
         <a href="https://inqlab.net">inqlab.net</a>
         <a href="https://inqlab.net/posts.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="134">
+      </span></li>
+      <li data-lang="en" id="134"><span>
         <a href="https://abstractxan.xyz">abstractxan.xyz</a>
-      </li>
-      <li data-lang="en" id="135">
+      </span></li>
+      <li data-lang="en" id="135"><span>
         <a href="https://mxmarin.ca">m-x marin</a>
-      </li>
-      <li data-lang="en" id="136">
+      </span></li>
+      <li data-lang="en" id="136"><span>
         <a href="https://metasyn.pw">metasyn</a>
         <a href="https://metasyn.pw/rss.xml" class="rss">rss</a>
         <img src="https://metasyn.pw/resources/img/mtsn.gif" />
-      </li>
-      <li data-lang="en" id="137">
+      </span></li>
+      <li data-lang="en" id="137"><span>
         <a href="https://www.milofultz.com">milofultz</a>
         <a href="https://milofultz.com/atom.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="138">
+      </span></li>
+      <li data-lang="en" id="138"><span>
         <a href="https://thomasorus.com">Thomasorus</a>
-      </li>
-      <li data-lang="en" id="neeasade">
+      </span></li>
+      <li data-lang="en" id="neeasade"><span>
         <a href="https://notes.neeasade.net/">neeasade</a>
         <a href="https://notes.neeasade.net/rss.xml" class="rss">rss</a>
-      <li data-lang="en" id="139">
+      <li data-lang="en" id="139"><span>
         <a href="https://notebook.wesleyac.com">wesleyac</a>
         <a href="https://notebook.wesleyac.com/atom.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="140">
+      </span></li>
+      <li data-lang="en" id="140"><span>
         <a href="https://irimi.one">irimi1</a>
         <a href="https://irimi.one/atom.xml" class="rss">rss</a>
         <img src="https://irimi.one/button.gif" />
-      </li>
-      <li data-lang="en" id="141">
+      </span></li>
+      <li data-lang="en" id="141"><span>
         <a href="https://wolfmd.me">wolfmd</a>
         <a href="https://wolfmd.me/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="142">
+      </span></li>
+      <li data-lang="en" id="142"><span>
         <a href="https://garden.tymon-zaniewski.xyz/">pxltr / tymon zaniewski</a>
-      </li>
-      <li data-lang="en" id="143">
+      </span></li>
+      <li data-lang="en" id="143"><span>
         <a href="https://void.cc">automata / vilson vieira</a>
-      </li>
-      <li data-lang="en" id="144">
+      </span></li>
+      <li data-lang="en" id="144"><span>
         <a href="https://hecanjog.com">he can jog</a>
         <a href="https://hecanjog.com/twtxt.txt" class="twtxt">twtxt</a>
         <img src="https://hecanjog.com/hcj-banner.gif"/>
-      </li>
-      <li data-lang="en" id="145">
+      </span></li>
+      <li data-lang="en" id="145"><span>
         <a href="http://fragmentscenario.com/">fragmentscenario</a>
         <img src="http://www.fragmentscenario.com/img/frgmnt_webbanner.gif"/>
-      </li>
-      <li data-lang="en" id="146">
+      </span></li>
+      <li data-lang="en" id="146"><span>
         <a href="https://mineralexistence.com/">Mineral Existence</a>
         <a href="https://mineralexistence.com/tw.txt" class="twtxt">twtxt</a>
         <img src='https://mineralexistence.com/images/icon.gif' />
-      </li>
-      <li data-lang="en" id="147">
+      </span></li>
+      <li data-lang="en" id="147"><span>
         <a href="https://aless.co">anti-pattern / alessia bellisario</a>
         <a href="https://aless.co/rss.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="148">
+      </span></li>
+      <li data-lang="en" id="148"><span>
         <a href="https://weakty.com">weakty</a>
-      </li>
-      <li data-lang="en" id="149">
+      </span></li>
+      <li data-lang="en" id="149"><span>
         <a href="https://0l.wtf">0l</a>
         <a href="https://0l.wtf/rss.xml" class="rss">rss</a>
         <a href="https://0l.wtf/twtxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="150">
+      </span></li>
+      <li data-lang="en" id="150"><span>
         <a href="https://mrshll.com">mrshll</a>
         <img src='https://mrshll.com/img/mmx_button.gif' />
-      </li>
-      <li data-lang="en" id="151">
+      </span></li>
+      <li data-lang="en" id="151"><span>
         <a href="https://everest-pipkin.com/">everest pipkin</a>
-      </li>
-      <li data-lang="fr" id="152">
+      </span></li>
+      <li data-lang="fr" id="152"><span>
         <a href="https://hugo.soucy.cc">hs0ucy</a>
         <a href="https://hugo.soucy.cc/index.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="153">
+      </span></li>
+      <li data-lang="en" id="153"><span>
         <a href="https://darch.dk">darch</a>
         <a href="https://darch.dk/twtxt.txt" class="twtxt">twtxt</a>
         <a href="https://darch.dk/feed/page:feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="natehn">
+      </span></li>
+      <li data-lang="en" id="natehn"><span>
         <a href="https://natehn.com">natehn</a>
         <a href="https://natehn.com/index.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="pbatch">
+      </span></li>
+      <li data-lang="en" id="pbatch"><span>
         <a href="https://pbat.ch">pbatch</a>
         <a href="https://pbat.ch/twtxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="156">
+      </span></li>
+      <li data-lang="en" id="156"><span>
         <a href="https://dom.ink">dom</a>
         <a href="https://dom.ink/tw.txt" class="twtxt">twtxt</a>
         <img src='https://dom.ink/img/button.gif' />
-      </li>
-      <li data-lang="en" id="157">
+      </span></li>
+      <li data-lang="en" id="157"><span>
         <a href="https://njoqi.me">njoqi</a>
-      </li>
-      <li data-lang="en" id="158">
+      </span></li>
+      <li data-lang="en" id="158"><span>
         <a href="https://eric.jetzt">eric.jetzt</a>
         <a href="https://eric.jetzt/twtxt.txt" class="twtxt">twtxt</a>
-      </li>
-      <li data-lang="en" id="gr0k">
+      </span></li>
+      <li data-lang="en" id="gr0k"><span>
         <a href="https://www.gr0k.net">gr0k</a>
         <a href="https://www.gr0k.net/twtxt.txt" class="twtxt">twtxt</a>
         <a href="https://www.gr0k.net/blog/feed.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="clarity">
+      </span></li>
+      <li data-lang="en" id="clarity"><span>
         <a href="https://clarity.flowers">Clarity Flowers</a>
-      </li>
-      <li data-lang="en" id="tendigits">
+      </span></li>
+      <li data-lang="en" id="tendigits"><span>
         <a href="https://tendigits.space">Ten Digits</a>
         <a href="https://tendigits.space/feed.xml" class="rss">rss</a>
         <img src="https://tendigits.space/assets/tendigits-webring.gif">
-      </li>
-      <li data-lang="en" id="162">
+      </span></li>
+      <li data-lang="en" id="162"><span>
         <a href="https://マリウス.com">マリウス</a>
         <a href="https://マリウス.com/index.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en de" id="163">
+      </span></li>
+      <li data-lang="en de" id="163"><span>
         <a href="https://sirtetris.com">sirtetris</a>
-      </li>
-      <li data-lang="en" id="rodrigo">
+      </span></li>
+      <li data-lang="en" id="rodrigo"><span>
         <a href="https://rodrigofranco.com">rodrigofranco</a>
-      </li>
-      <li data-lang="en" id="oppen">
+      </span></li>
+      <li data-lang="en" id="oppen"><span>
         <a href="https://oppen.digital">Öppen</a>
-      </li>
-      <li data-lang="en" id="164">
+      </span></li>
+      <li data-lang="en" id="164"><span>
         <a href="https://itwont.work"> itwont.work </a>
         <a href="https://itwont.work/atom.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="bad10de">
+      </span></li>
+      <li data-lang="en" id="bad10de"><span>
         <a href="https://badd10de.dev">badd10de</a>
         <a href="https://badd10de.dev/feed.xml" class="rss">rss</a>
         <img src="https://badd10de.dev/assets/webring_icn.gif" />
-      </li>
-      <li data-lang="en" id="nilfm">
+      </span></li>
+      <li data-lang="en" id="nilfm"><span>
         <a href="https://nilfm.cc">nilFM</a>
-      </li>
-      <li data-lang="en" id="166">
+      </span></li>
+      <li data-lang="en" id="166"><span>
         <a href="https://voidjumper.glass">voidjumper.glass</a>
-      </li>
-      <li data-lang="en" id="pixouls">
+      </span></li>
+      <li data-lang="en" id="pixouls"><span>
         <a href="https://pixouls.xyz">pixouls</a>
-      </li>
-      <li data-lang="en" id="embyr">
+      </span></li>
+      <li data-lang="en" id="embyr"><span>
         <a href="https://embyr.sh"><i>embyr.sh</i></a>
         <a href="https://embyr.sh/index.xml" class="rss">rss</a>
-      </li>
-      <li data-lang="en" id="maxhaesslein">
+      </span></li>
+      <li data-lang="en" id="maxhaesslein"><span>
         <a href="https://www.maxhaesslein.de">maxhaesslein.de</a>
-      </li>
-		<li data-lang="en" id="daisy">
+      </span></li>
+		<li data-lang="en" id="daisy"><span>
 			<a href="https://daisy.gaiwan.org">daisy</a>
 			<a href="https://daisy.gaiwan.org/atom.xml" class="rss">rss</a>
 			<img src="https://daisy.gaiwan.org/button.gif"/>
-		</li>
+		</span></li>
 	</ol>
     <footer>
       <p class="readme">
@@ -674,7 +674,7 @@ body > footer > p span.hide { display: none; }
 body > footer > img { display: inline-block; width: 100px; margin-bottom: -5px; margin-bottom: 30px; }
 body:target > ol li a.twtxt, html:target li a.rss { background: var(--color-beta); color: var(--color-alpha); display: inline; }
 body:target > footer > p > span.hide, html:target footer > p > span.hide { display: inline; }
-body > ol:target > li > img { display:block; }
+body > ol:target > li img { display:block; }
 body > ol > li:target a { color: var(--color-alpha); }
 body > ol > li:target { background: var(--color-beta); }
 @media screen and (max-width: 800px) { body > ol { column-count: 2; } }

--- a/index.html
+++ b/index.html
@@ -637,7 +637,12 @@
       <li data-lang="en" id="maxhaesslein">
         <a href="https://www.maxhaesslein.de">maxhaesslein.de</a>
       </li>
-    </ol>
+		<li data-lang="en" id="daisy">
+			<a href="https://daisy.gaiwan.org">daisy</a>
+			<a href="https://daisy.gaiwan.org/atom.xml" class="rss">rss</a>
+			<img src="https://daisy.gaiwan.org/button.gif"/>
+		</li>
+	</ol>
     <footer>
       <p class="readme">
         This webring is an attempt to inspire artists &amp; developers to build their websites and share traffic amongst each other. The ring welcomes <b>hand-crafted wikis and portfolios</b>.


### PR DESCRIPTION
li (list item) tags necessarily have a CSS display of "list-item", which may cause their contents to spill across the ends of columns. By wrapping their contents with a span tag, the contents are fit into an "inline" element and stick together.