### PR TITLE
Wrapping li contents in span tags (attempt 2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,798 +9,798 @@
 	</head>
 	<body id="twtxt">
 		<ol id="icons">
-			<li data-lang="en" id="xxiivv">
+			<li data-lang="en" id="xxiivv"><span>
 				<a href="https://wiki.xxiivv.com">xxiivv</a>
 				<a href="https://journal.miso.town/atom?url=https://wiki.xxiivv.com/site/now.html" class="rss">rss</a>
 				<img loading="lazy" src='https://wiki.xxiivv.com/media/services/button.gif' width="88" height="31">
-			</li>
-			<li data-lang="en" id="2">
+			</span></li>
+			<li data-lang="en" id="2"><span>
 				<a href="https://electro.pizza">electro pizza</a>
 				<a href="https://electro.pizza/twtxt.txt" class="twtxt">twtxt</a>
 				<a href="https://electro.pizza/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="avanier">
+			</span></li>
+			<li data-lang="en" id="avanier"><span>
 				<a href="https://avanier.dev">avanier</a>
 				<a href="https://avanier.dev/tw.txt" class="twtxt">twtxt</a>
 				<img loading="lazy" src="https://avanier.dev/m/88x31.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="5">
+			</span></li>
+			<li data-lang="en" id="5"><span>
 				<a href="https://detritus.zone">detritus.zone</a>
 				<a href="https://detritus.zone/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://detritus.zone/img/detritus.zone-88x31.png" width="88" height="31">
-			</li>
-			<li data-lang="en" id="6">
+			</span></li>
+			<li data-lang="en" id="6"><span>
 				<a href="https://hraew.autophagy.io">hraew.autophagy</a>
-			</li>
-			<li data-lang="en el" id="heracles">
+			</span></li>
+			<li data-lang="en el" id="heracles"><span>
 				<a href="https://heracl.es">heracl.es</a>
 				<a href="https://heracl.es/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="12">
+			</span></li>
+			<li data-lang="en" id="12"><span>
 				<a href="https://now.lectronice.com">lectronice</a>
 				<a href="https://now.lectronice.com/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://now.lectronice.com/lctrncbttn.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="13">
+			</span></li>
+			<li data-lang="en" id="13"><span>
 				<a href="https://craze.co.uk">craze.co.uk</a>
-			</li>
-			<li data-lang="en" id="14">
+			</span></li>
+			<li data-lang="en" id="14"><span>
 				<a href="https://shaneckel.com">shaneckel</a>
-			</li>
-			<li data-lang="en" id="15">
+			</span></li>
+			<li data-lang="en" id="15"><span>
 				<a href="https://cblgh.org">cblgh</a>
 				<a href="https://cblgh.org/all.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://cblgh.org/dl/cblgh-webring.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="16">
+			</span></li>
+			<li data-lang="en" id="16"><span>
 				<a href="https://ellugar.co">ellugar</a>
 				<a href="http://feeds.ellugar.co/ellugar-logs" class="rss">rss</a>
 				<img loading="lazy" src="https://ellugar.co/img/button.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="17">
+			</span></li>
+			<li data-lang="en" id="17"><span>
 				<a href="http://chigby.org">chigby</a>
-			</li>
-			<li data-lang="en" id="18">
+			</span></li>
+			<li data-lang="en" id="18"><span>
 				<a href="https://longest.voyage">longest.voyage</a>
 				<a href="https://longest.voyage/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="19">
+			</span></li>
+			<li data-lang="en" id="19"><span>
 				<a href="https://palomakop.tv">palomakop.tv</a>
 				<a href="https://palomakop.tv/rss.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://palomakop.tv/button.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="20">
+			</span></li>
+			<li data-lang="en" id="20"><span>
 				<a href="https://v-os.ca">v-os.ca</a>
-			</li>
-			<li data-lang="en" id="22">
+			</span></li>
+			<li data-lang="en" id="22"><span>
 				<a href="https://2d4.dev">2d4.dev</a>
 				<a href="https://2d4.dev/tw.txt" class="twtxt">twtxt</a>
-			</li>
-			<li data-lang="en" id="23">
+			</span></li>
+			<li data-lang="en" id="23"><span>
 				<a href="https://nathanwentworth.co">nathanwentworth</a>
-			</li>
-			<li data-lang="en" id="26">
+			</span></li>
+			<li data-lang="en" id="26"><span>
 				<a href="https://wasin.io">wasin</a>
-			</li>
-			<li data-lang="en" id="27">
+			</span></li>
+			<li data-lang="en" id="27"><span>
 				<a href="https://inns.studio">inns.studio</a>
-			</li>
-			<li data-lang="en" id="28">
+			</span></li>
+			<li data-lang="en" id="28"><span>
 				<a href="http://kokorobot.ca">kokorobot.ca</a>
 				<img loading="lazy" src="https://kokorobot.ca/media/interface/button.gif" width="88" height="31">
 				<a href="https://kokorobot.ca/links/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="29">
+			</span></li>
+			<li data-lang="en" id="29"><span>
 				<a href="https://ameyama.com">ameyama</a>
 				<a href="https://ameyama.com/blog/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="30">
+			</span></li>
+			<li data-lang="en" id="30"><span>
 				<a href="https://wake.st">wake.st</a>
 				<a href="https://wake.st/twtxt.txt" class="twtxt">twtxt</a>
 				<img loading="lazy" src="https://wake.st/webring/banner.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="31">
+			</span></li>
+			<li data-lang="en" id="31"><span>
 				<a href="https://xarene.la">xarene.la</a>
-			</li>
-			<li data-lang="en" id="33">
+			</span></li>
+			<li data-lang="en" id="33"><span>
 				<a href="http://bildwissenschaft.vortok.info">vortok</a>
-			</li>
-			<li data-lang="en" id="35">
+			</span></li>
+			<li data-lang="en" id="35"><span>
 				<a href="https://aeriform.io">aeriform.io</a>
-			</li>
-			<li data-lang="en" id="37">
+			</span></li>
+			<li data-lang="en" id="37"><span>
 				<a href="http://nonmateria.com">nonmateria</a>
 				<a href="http://nonmateria.com/rss.xml" class="rss">rss</a>
 				<img loading="lazy" src="http://nonmateria.com/data/avatars/banner.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="39">
+			</span></li>
+			<li data-lang="en" id="39"><span>
 				<a href="https://drisc.io">drisc</a>
-			</li>
-			<li data-lang="en" id="40">
+			</span></li>
+			<li data-lang="en" id="40"><span>
 				<a href="https://ricky.codes">ricky.codes</a>
-			</li>
-			<li data-lang="en" id="41">
+			</span></li>
+			<li data-lang="en" id="41"><span>
 				<a href="https://maxdeviant.com">maxdeviant</a>
 				<a href="https://maxdeviant.com/atom.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="42">
+			</span></li>
+			<li data-lang="en" id="42"><span>
 				<a href="https://tynandebold.com">tynandebold</a>
-			</li>
-			<li data-lang="en" id="44">
+			</span></li>
+			<li data-lang="en" id="44"><span>
 				<a href="https://nomand.co">nomand.co</a>
-			</li>
-			<li data-lang="en" id="46">
+			</span></li>
+			<li data-lang="en" id="46"><span>
 				<a href="https://mmm.s-ol.nu">s-ol.nu</a>
-			</li>
-			<li data-lang="en" id="48">
+			</span></li>
+			<li data-lang="en" id="48"><span>
 				<a href="https://smidgeo.com/bots">smidgeo.com/bots</a>
-			</li>
-			<li data-lang="en ru" id="49">
+			</span></li>
+			<li data-lang="en ru" id="49"><span>
 				<a href="https://iko.soy">iko.soy</a>
-			</li>
-			<li data-lang="en" id="50">
+			</span></li>
+			<li data-lang="en" id="50"><span>
 				<a href="https://ritualdust.com">ritual dust</a>
 				<a href="https://ritualdust.com/index.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://ritualdust.com/img/button.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="51">
+			</span></li>
+			<li data-lang="en" id="51"><span>
 				<a href="https://magoz.is">magoz.is</a>
-			</li>
-			<li data-lang="en" id="52">
+			</span></li>
+			<li data-lang="en" id="52"><span>
 				<a href="https://szymonkaliski.com">szymonkaliski</a>
 				<a href="https://szymonkaliski.com/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="54">
+			</span></li>
+			<li data-lang="en" id="54"><span>
 				<a href="https://rosano.ca">rosano.ca</a>
 				<a href="https://rosano.ca/feed" class="rss">rss</a>
 				<img loading="lazy" src="https://static.rosano.ca/_shared/webring-button.gif" width="88" height="31">
-			</li>
-			<li data-lang="en zh" id="58">
+			</span></li>
+			<li data-lang="en zh" id="58"><span>
 				<a href="https://yiming.dev/">yiming.dev</a>
-			</li>
-			<li data-lang="en" id="60">
+			</span></li>
+			<li data-lang="en" id="60"><span>
 				<a href="https://boffosocko.com">boffosocko</a>
-			</li>
-			<li data-lang="en" id="61">
+			</span></li>
+			<li data-lang="en" id="61"><span>
 				<a href="https://hex22.org">hex22</a>
-			</li>
-			<li data-lang="en" id="62">
+			</span></li>
+			<li data-lang="en" id="62"><span>
 				<a href="https://patrikarvidsson.com">patrikarvidsson</a>
-			</li>
-			<li data-lang="en" id="63">
+			</span></li>
+			<li data-lang="en" id="63"><span>
 				<a href="https://sophieleetmaa.com">sophieleetmaa</a>
-			</li>
-			<li data-lang="en" id="64">
+			</span></li>
+			<li data-lang="en" id="64"><span>
 				<a href="https://xinniw.net">xinniw</a>
-			</li>
-			<li data-lang="en" id="67">
+			</span></li>
+			<li data-lang="en" id="67"><span>
 				<a href="https://tom.so">tom hackshaw</a>
-			</li>
-			<li data-lang="es" id="70">
+			</span></li>
+			<li data-lang="es" id="70"><span>
 				<a href="https://www.madewithtea.com">madewithtea</a>
-			</li>
-			<li data-lang="en" id="73">
+			</span></li>
+			<li data-lang="en" id="73"><span>
 				<a href="https://buzzert.net">buzzert.net</a>
-			</li>
-			<li data-lang="en" id="75">
+			</span></li>
+			<li data-lang="en" id="75"><span>
 				<a href="https://serocell.com">serocell.com</a>
 				<a href="https://serocell.com/feeds/serocell.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="76">
+			</span></li>
+			<li data-lang="en" id="76"><span>
 				<a href="https://kor.nz">kor</a>
 				<a href="https://kor.nz/twtxt.txt" class="twtxt">twtxt</a>
-			</li>
-			<li data-lang="en" id="77">
+			</span></li>
+			<li data-lang="en" id="77"><span>
 				<a href="https://lublin.se">lublin.se</a>
-			</li>
-			<li data-lang="en" id="78">
+			</span></li>
+			<li data-lang="en" id="78"><span>
 				<a href="https://zanneth.com">zanneth</a>
-			</li>
-			<li data-lang="en" id="79">
+			</span></li>
+			<li data-lang="en" id="79"><span>
 				<a href="https://eli.li">eli.li</a>
 				<a href="https://eli.li/feed.rss" class="rss">rss</a>
 				<img loading="lazy" src="https://eli.li/_assets/_images/badge/02_88x31.png" width="88" height="31">
-			</li>
-			<li data-lang="en" id="80">
+			</span></li>
+			<li data-lang="en" id="80"><span>
 				<a href="https://gosha.net">gosha.net</a>
 				<a href="https://gosha.net/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://gosha.net/assets/images/88x31.svg" width="88" height="31">
-			</li>
-			<li data-lang="en" id="82">
+			</span></li>
+			<li data-lang="en" id="82"><span>
 				<a href="https://azlen.me">azlen.me</a>
 				<a href="https://azlen.me/twtxt.txt" class="twtxt">twtxt</a>
-			</li>
-			<li data-lang="en" id="83">
+			</span></li>
+			<li data-lang="en" id="83"><span>
 				<a href="https://opguides.info">OpGuides</a>
 				<img loading="lazy" src="https://opguides.info/nonfree/logo/opguides3.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="84">
+			</span></li>
+			<li data-lang="en" id="84"><span>
 				<a href="https://chrismaughan.com/">CMaughan</a>
 				<a href="https://chrismaughan.com/twtxt.txt" class="twtxt">twtxt</a>
-			</li>
-			<li data-lang="en it" id="85">
+			</span></li>
+			<li data-lang="en it" id="85"><span>
 				<a href="https://oddworlds.org">oddworlds soliloquy</a>
 				<a href="https://oddworlds.org/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="86">
+			</span></li>
+			<li data-lang="en" id="86"><span>
 				<a href="https://fundor333.com/">Fundor333</a>
 				<a href="https://fundor333.com/twtxt.txt" class="twtxt">twtxt</a>
-			</li>
-			<li data-lang="en" id="87">
+			</span></li>
+			<li data-lang="en" id="87"><span>
 				<a href="https://cass.si">cass.si</a>
-			</li>
-			<li data-lang="de" id="89">
+			</span></li>
+			<li data-lang="de" id="89"><span>
 				<a href="https://mdbenning.neocities.org/">mdbenning</a>
-			</li>
-			<li data-lang="en" id="90">
+			</span></li>
+			<li data-lang="en" id="90"><span>
 				<a href="https://resevoir.net">resevoir</a>
 				<a href="https://resevoir.net/rss.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://resevoir.net/images/button.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="91">
+			</span></li>
+			<li data-lang="en" id="91"><span>
 				<a href="https://sixey.es/">sixey.es</a>
 				<img loading="lazy" src="https://sixey.es/6e20ass/8831.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="93">
+			</span></li>
+			<li data-lang="en" id="93"><span>
 				<a href="https://jameschip.io">James Chip</a>
 				<a href="https://jameschip.io/index.xml" class="rss">rss</a>
 				<img loading="lazy" src='https://jameschip.io/media/icons/jc88x31.gif' width="88" height="31">
-			</li>
-			<li data-lang="en" id="94">
+			</span></li>
+			<li data-lang="en" id="94"><span>
 				<a href="https://patrick-is.cool">patrick-is.cool</a>
-			</li>
-			<li data-lang="en" id="95">
+			</span></li>
+			<li data-lang="en" id="95"><span>
 				<a href="https://icyphox.sh">icyphox.sh</a>
 				<a href="https://icyphox.sh/blog/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="98">
+			</span></li>
+			<li data-lang="en" id="98"><span>
 				<a href="https://crlf.link">Cr;Lf;</a>
 				<a href="https://crlf.link/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="99">
+			</span></li>
+			<li data-lang="en" id="99"><span>
 				<a href="https://esi.is">Jóhannes G. Þorsteinsson</a>
-			</li>
-			<li data-lang="en" id="102">
+			</span></li>
+			<li data-lang="en" id="102"><span>
 				<a href="https://rezmason.net">rezmason.net</a>
 				<img loading="lazy" src="https://www.rezmason.net/assets/button.gif" width="88" height="31">
-			</li>
-			<li data-lang="en cz" id="103">
+			</span></li>
+			<li data-lang="en cz" id="103"><span>
 				<a href="https://estfyr.net">estfyr.net</a>
-			</li>
-			<li data-lang="en" id="105">
+			</span></li>
+			<li data-lang="en" id="105"><span>
 				<a href="https://natwelch.com">Nat Welch</a>
 				<a href="https://writing.natwelch.com/feed.rss" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="106">
+			</span></li>
+			<li data-lang="en" id="106"><span>
 				<a href="https://parkimminent.com">Park Imminent</a>
-			</li>
-			<li data-lang="en" id="108">
+			</span></li>
+			<li data-lang="en" id="108"><span>
 				<a href="https://0xff.nu">Paul Glushak</a>
-			</li>
-			<li data-lang="en ita" id="109">
+			</span></li>
+			<li data-lang="en ita" id="109"><span>
 				<a href="https://simone.computer">Simone's Computer</a>
 				<a href="https://system31.simone.computer/rss.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://system31.simone.computer/assets/88x31.gif" width="88" height="31">
-			</li>
-			<li data-lang="en es eo" id="0x6c88354e70">
+			</span></li>
+			<li data-lang="en es eo" id="0x6c88354e70"><span>
 				<a href="https://sunshinegardens.org/~xj9/">dreamspace</a>
 				<a href="https://sunshinegardens.org/~xj9/feed.atom" class="rss">rss</a>
 				<a href="https://sunshinegardens.org/~xj9/twtxt/tw.txt" class="twtxt">twtxt</a>
 				<img loading="lazy" src="https://sunshinegardens.org/~xj9/activelink.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="112">
+			</span></li>
+			<li data-lang="en" id="112"><span>
 				<a href="http://q.pfiffer.org/">q.pfiffer.org</a>
 				<a href="http://q.pfiffer.org/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="114">
+			</span></li>
+			<li data-lang="en" id="114"><span>
 				<a href="https://zvava.org">zvava</a>
 				<img loading="lazy" src="https://zvava.org/images/buttons/zvava.org.png" width="88" height="31">
-			</li>
-			<li data-lang="en" id="115">
+			</span></li>
+			<li data-lang="en" id="115"><span>
 				<a href="https://amorphic.space">amorphic.space</a>
-			</li>
-			<li data-lang="en nl" id="116">
+			</span></li>
+			<li data-lang="en nl" id="116"><span>
 				<a href="https://www.edwinwenink.xyz">Archive Fever</a>
 				<a href="https://www.edwinwenink.xyz/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en fr" id="117">
+			</span></li>
+			<li data-lang="en fr" id="117"><span>
 				<a href="https://www.mentalnodes.com">Mental Nodes</a>
-			</li>
-			<li data-lang="es" id="118">
+			</span></li>
+			<li data-lang="es" id="118"><span>
 				<a href="https://copiona.com">copiona</a>
-			</li>
-			<li data-lang="en nl" id="119">
+			</span></li>
+			<li data-lang="en nl" id="119"><span>
 				<a href="https://proycon.anaproy.nl">proycon</a>
-			</li>
-			<li data-lang="en" id="121">
+			</span></li>
+			<li data-lang="en" id="121"><span>
 				<a href="https://roytang.net">roytang.net</a>
 				<a href="https://roytang.net/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="dampfkraft">
+			</span></li>
+			<li data-lang="en" id="dampfkraft"><span>
 				<a href="https://dampfkraft.com">Dampfkraft</a>
 				<a href="https://dampfkraft.com/index.rss" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="125">
+			</span></li>
+			<li data-lang="en" id="125"><span>
 				<a href="https://travisshears.com">travisshears</a>
 				<a href="https://travisshears.com/apps/twtxt/twtxt.txt" class="twtxt">twtxt</a>
 				<a href="https://travisshears.com/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="126">
+			</span></li>
+			<li data-lang="en" id="126"><span>
 				<a href="https://awalvie.me">awalvie</a>
-			</li>
-			<li data-lang="en ru" id="futuristan">
+			</span></li>
+			<li data-lang="en ru" id="futuristan"><span>
 				<a href="https://futuristan.io">futuristan.io</a>
-			</li>
-			<li data-lang="en" id="127">
+			</span></li>
+			<li data-lang="en" id="127"><span>
 				<a href="https://yctct.com/">yctct</a>
 				<a href="https://www.yctct.com/twtxt.txt" class="twtxt">twtxt</a>
 				<a href="https://www.yctct.com/feed.rss" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="ix5">
+			</span></li>
+			<li data-lang="en" id="ix5"><span>
 				<a href="https://ix5.org/">Felix Elsner</a>
 				<a href="https://ix5.org/thoughts/feeds/all.atom.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="128">
+			</span></li>
+			<li data-lang="en" id="128"><span>
 				<a href="https://www.juliendesrosiers.com/">Julien Desrosiers</a>
 				<a href="https://www.juliendesrosiers.com/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="129">
+			</span></li>
+			<li data-lang="en" id="129"><span>
 				<a href="https://nchrs.xyz">nchrs.xyz</a>
 				<a href="https://nchrs.xyz/links/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="northerinformation">
+			</span></li>
+			<li data-lang="en" id="northerinformation"><span>
 				<a href="https://nor.the-rn.info">Northern Information</a>
 				<a href="https://nor.the-rn.info/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="131">
+			</span></li>
+			<li data-lang="en" id="131"><span>
 				<a href="https://matildepark.ca">Matilde Park</a>
 				<a href="https://matildepark.ca/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="deianeira">
+			</span></li>
+			<li data-lang="en" id="deianeira"><span>
 				<a href="https://deianeira.co">deianeira.co</a>
 				<img loading="lazy" src="https://deianeira.co/res/88x31.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="133">
+			</span></li>
+			<li data-lang="en" id="133"><span>
 				<a href="https://inqlab.net">inqlab.net</a>
 				<a href="https://inqlab.net/posts.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="134">
+			</span></li>
+			<li data-lang="en" id="134"><span>
 				<a href="https://abstractxan.xyz">abstractxan.xyz</a>
-			</li>
-			<li data-lang="en" id="135">
+			</span></li>
+			<li data-lang="en" id="135"><span>
 				<a href="https://mxmarin.ca">m-x marin</a>
-			</li>
-			<li data-lang="en" id="136">
+			</span></li>
+			<li data-lang="en" id="136"><span>
 				<a href="https://metasyn.pw">metasyn</a>
 				<a href="https://metasyn.pw/rss.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://metasyn.pw/resources/video/mtsn.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="137">
+			</span></li>
+			<li data-lang="en" id="137"><span>
 				<a href="https://www.milofultz.com">milofultz</a>
-			</li>
-			<li data-lang="en" id="138">
+			</span></li>
+			<li data-lang="en" id="138"><span>
 				<a href="https://thomasorus.com">Thomasorus</a>
-			</li>
-			<li data-lang="en" id="neeasade">
+			</span></li>
+			<li data-lang="en" id="neeasade"><span>
 				<a href="https://notes.neeasade.net/">neeasade</a>
 				<a href="https://notes.neeasade.net/rss.xml" class="rss">rss</a>
-			<li data-lang="en" id="139">
+			<li data-lang="en" id="139"><span>
 				<a href="https://notebook.wesleyac.com">wesleyac</a>
 				<a href="https://notebook.wesleyac.com/atom.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="141">
+			</span></li>
+			<li data-lang="en" id="141"><span>
 				<a href="https://wolfmd.me">wolfmd</a>
 				<a href="https://wolfmd.me/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://wolfmd.me/img/banner.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="143">
+			</span></li>
+			<li data-lang="en" id="143"><span>
 				<a href="https://void.cc">automata / vilson vieira</a>
-			</li>
-			<li data-lang="en" id="144">
+			</span></li>
+			<li data-lang="en" id="144"><span>
 				<a href="https://hecanjog.com">he can jog</a>
 				<a href="https://hecanjog.com/twtxt.txt" class="twtxt">twtxt</a>
 				<img loading="lazy" src="https://hecanjog.com/hcj-banner.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="145">
+			</span></li>
+			<li data-lang="en" id="145"><span>
 				<a href="http://fragmentscenario.com/">fragmentscenario</a>
-			</li>
-			<li data-lang="en" id="146">
+			</span></li>
+			<li data-lang="en" id="146"><span>
 				<a href="https://corvid.cafe/">corvid cafe</a>
 				<a href="https://corvid.cafe/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src='https://corvid.cafe/images/icon.gif' width="88" height="31">
-			</li>
-			<li data-lang="en" id="147">
+			</span></li>
+			<li data-lang="en" id="147"><span>
 				<a href="https://aless.co">anti-pattern / alessia bellisario</a>
 				<a href="https://aless.co/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="148">
+			</span></li>
+			<li data-lang="en" id="148"><span>
 				<a href="https://weakty.com">weakty</a>
-			</li>
-			<li data-lang="en" id="150">
+			</span></li>
+			<li data-lang="en" id="150"><span>
 				<a href="https://mrshll.com">mrshll</a>
 				<a href="https://mrshll.com/feed.rss" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="151">
+			</span></li>
+			<li data-lang="en" id="151"><span>
 				<a href="https://everest-pipkin.com/">everest pipkin</a>
-			</li>
-			<li data-lang="fr" id="152">
+			</span></li>
+			<li data-lang="fr" id="152"><span>
 				<a href="https://hugo.soucy.cc">hs0ucy</a>
 				<a href="https://hugo.soucy.cc/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="notebook.hew.tt">
+			</span></li>
+			<li data-lang="en" id="notebook.hew.tt"><span>
 				<a href="https://notebook.hew.tt">notebook.hew.tt</a>
 				<a href="https://notebook.hew.tt/index.xml" class="rss">rss</a>
 				<img loading="lazy" src='https://notebook.hew.tt/animated-icon.gif' width="88" height="31">
-			</li>
-			<li data-lang="en" id="pbatch">
+			</span></li>
+			<li data-lang="en" id="pbatch"><span>
 				<a href="https://pbat.ch">pbatch</a>
 				<a href="https://pbat.ch/twtxt.txt" class="twtxt">twtxt</a>
-			</li>
-			<li data-lang="en" id="157">
+			</span></li>
+			<li data-lang="en" id="157"><span>
 				<a href="https://njoqi.me">njoqi</a>
-			</li>
-			<li data-lang="en" id="gr0k">
+			</span></li>
+			<li data-lang="en" id="gr0k"><span>
 				<a href="https://www.gr0k.net">gr0k</a>
 				<a href="https://www.gr0k.net/twtxt.txt" class="twtxt">twtxt</a>
 				<a href="https://www.gr0k.net/blog/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="clarity">
+			</span></li>
+			<li data-lang="en" id="clarity"><span>
 				<a href="https://clarity.flowers">Clarity Flowers</a>
-			</li>
-			<li data-lang="en" id="tendigits">
+			</span></li>
+			<li data-lang="en" id="tendigits"><span>
 				<a href="https://tendigits.space">Ten Digits</a>
 				<a href="https://tendigits.space/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://tendigits.space/assets/tendigits-webring.gif" width="88" height="31">
-			</li>
-			<li data-lang="en de" id="163">
+			</span></li>
+			<li data-lang="en de" id="163"><span>
 				<a href="https://sirtetris.com">sirtetris</a>
-			</li>
-			<li data-lang="en" id="caffeine">
+			</span></li>
+			<li data-lang="en" id="caffeine"><span>
 				<a href="https://caffeine.wiki">caffeine</a>
 				<a href="https://caffeine.wiki/atom.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://caffeine.wiki/caffeine-button.png" width="88" height="31">
-			</li>
-			<li data-lang="en" id="164">
+			</span></li>
+			<li data-lang="en" id="164"><span>
 				<a href="https://itwont.work"> itwont.work </a>
 				<a href="https://itwont.work/atom.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="bad10de">
+			</span></li>
+			<li data-lang="en" id="bad10de"><span>
 				<a href="https://badd10de.dev">badd10de</a>
 				<img loading="lazy" src="https://badd10de.dev/assets/webring_icn.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="nilfm">
+			</span></li>
+			<li data-lang="en" id="nilfm"><span>
 				<a href="https://nilfm.cc">nilFM</a>
 				<a href="https://nilfm.cc/twtxt.txt" class="twtxt">twtxt</a>
 				<img loading="lazy" src="https://nilfm.cc/img/webring_banner.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="wilde-at-heart">
+			</span></li>
+			<li data-lang="en" id="wilde-at-heart"><span>
 				<a href="https://wilde-at-heart.garden">wilde at heart</a>
-			</li>
-			<li data-lang="en" id="pixouls">
+			</span></li>
+			<li data-lang="en" id="pixouls"><span>
 				<a href="https://pixouls.xyz">pixouls</a>
 				<a href="https://www.pixouls.xyz/rss.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://www.pixouls.xyz/files/button.png" width="88" height="31">
-			</li>
-			<li data-lang="en" id="embyr">
+			</span></li>
+			<li data-lang="en" id="embyr"><span>
 				<a href="https://embyr.sh"><i>embyr.sh</i></a>
 				<a href="https://embyr.sh/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="maxhaesslein">
+			</span></li>
+			<li data-lang="en" id="maxhaesslein"><span>
 				<a href="https://www.maxhaesslein.de">maxhaesslein.de</a>
-			</li>
-			<li data-lang="en" id="compudanzas">
+			</span></li>
+			<li data-lang="en" id="compudanzas"><span>
 				<a href="https://compudanzas.net">compudanzas</a>
 				<a href="https://compudanzas.net/tw.txt" class="twtxt">twtxt</a>
 				<a href="https://compudanzas.net/atom.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="yhnck">
+			</span></li>
+			<li data-lang="en" id="yhnck"><span>
 				<a href="https://yhnck.xyz">yhancik</a>
 				<img loading="lazy" src="https://yhnck.xyz/button.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="astralbijection">
+			</span></li>
+			<li data-lang="en" id="astralbijection"><span>
 				<a href="https://astrid.tech">astral&harr;bijection</a>
 				<a href="https://astrid.tech/tw.txt" class="twtxt">twtxt</a>
 				<a href="https://astrid.tech/atom.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="flower-codes">
+			</span></li>
+			<li data-lang="en" id="flower-codes"><span>
 				<a href="http://flower.codes">flower.codes</a>
 				<a href="http://flower.codes/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="noelle-dev">
+			</span></li>
+			<li data-lang="en" id="noelle-dev"><span>
 				<a href="https://noelle.dev">noelle.dev</a>
 				<img loading="lazy" src="https://noelle.dev/assets/images/button.gif" style="image-rendering: pixelated;" width="88" height="31">
-			</li>
-			<li data-lang="en" id="giacinto-carlucci">
+			</span></li>
+			<li data-lang="en" id="giacinto-carlucci"><span>
 				<a href="https://www.giacintocarlucci.it">giacintocarlucci.it</a>
-			</li>
-			<li data-lang="en" id="paritybit">
+			</span></li>
+			<li data-lang="en" id="paritybit"><span>
 				<a href="https://www.paritybit.ca">paritybit.ca</a>
 				<a href="https://www.paritybit.ca/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://www.paritybit.ca/img/88x31icon.png" width="88" height="31">
-			</li>
-			<li data-lang="en" id="vlad.website">
+			</span></li>
+			<li data-lang="en" id="vlad.website"><span>
 				<a href="https://vlad.website">vlad.website</a>
 				<a href="https://vlad.website/index.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://vlad.website/images/banner.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="d6">
+			</span></li>
+			<li data-lang="en" id="d6"><span>
 				<a href="http://plastic-idolatry.com/erik">Plastic Idolatry</a>
-			</li>
-			<li data-lang="fr" id="ferale">
+			</span></li>
+			<li data-lang="fr" id="ferale"><span>
 				<a href="https://ferale.art">Ferale Art</a>
 				<a href="https://ferale.art/feed" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="toyos.dev">
+			</span></li>
+			<li data-lang="en" id="toyos.dev"><span>
 				<a href="https://toyos.dev/">toyos.dev</a>
-			</li>
-			<li data-lang="en zh" id="well-observe">
+			</span></li>
+			<li data-lang="en zh" id="well-observe"><span>
 				<a href="https://www.wellobserve.com/">Well Observe</a>
 				<a href="https://www.wellobserve.com/index.php?rss=en" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="d00k">
+			</span></li>
+			<li data-lang="en" id="d00k"><span>
 				<a href="https://d00k.net/">D00k</a>
 				<a href="https://d00k.net/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="detondev">
+			</span></li>
+			<li data-lang="en" id="detondev"><span>
 				<a href="https://detondev.com">DetonDev</a>
 				<img loading="lazy" src='https://detondev.com/images/self/button.gif' width="88" height="31">
-			</li>
-			<li data-lang="en fr de" id="arcade">
+			</span></li>
+			<li data-lang="en fr de" id="arcade"><span>
 				<a href="https://arcades.agency">Aethopica</a>
-			</li>
-			<li data-lang="en de fr" id="jachere">
+			</span></li>
+			<li data-lang="en de fr" id="jachere"><span>
 				<a href="https://jache.re">jache.re</a>
-			</li>
-			<li data-lang="en" id="helveticablanc">
+			</span></li>
+			<li data-lang="en" id="helveticablanc"><span>
 				<a href="https://helveticablanc.com/">Helvetica Blanc</a>
 				<a href="https://helveticablanc.com/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://helveticablanc.com/img/button.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="colindrake">
+			</span></li>
+			<li data-lang="en" id="colindrake"><span>
 				<a href="https://colindrake.me">colindrake.me</a>
-			</li>
-			<li data-lang="en" id="tonesupport">
+			</span></li>
+			<li data-lang="en" id="tonesupport"><span>
 				<a href="https://log.tone.support">tone.support</a>
-			</li>
-			<li data-lang="en" id="armaina">
+			</span></li>
+			<li data-lang="en" id="armaina"><span>
 				<a href="http://armaina.com/">armaina</a>
 				<a href="http://armaina.com/rss.xml" class="rss">rss</a>
 				<img loading="lazy" src="http://armaina.com/88x31.jpg" width="88" height="31">
-			</li>
-			<li data-lang="en" id="sindhulive">
+			</span></li>
+			<li data-lang="en" id="sindhulive"><span>
 				<a href="https://sindhu.live">sindhu.live</a>
-			</li>
-			<li data-lang="en" id="nuel">
+			</span></li>
+			<li data-lang="en" id="nuel"><span>
 				<a href="https://nuel.pw">nuel</a>
 				<img loading="lazy" src="https://nuel.pw/button.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="ffsanton">
+			</span></li>
+			<li data-lang="en" id="ffsanton"><span>
 				<a href="https://ffs.fm">ffs.fm</a>
-			</li>
-			<li data-lang="en" id="aphrodite.dev">
+			</span></li>
+			<li data-lang="en" id="aphrodite.dev"><span>
 				<a href="https://www.aphrodite.dev/">aphrodite.dev</a>
 				<a href="https://www.aphrodite.dev/~blog/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://www.aphrodite.dev/badge.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="zealco">
+			</span></li>
+			<li data-lang="en" id="zealco"><span>
 				<a href="https://zeal.co">zeal.co</a>
-			</li>
-			<li data-lang="en" id="canalswans">
+			</span></li>
+			<li data-lang="en" id="canalswans"><span>
 				<a href="https://canalswans.commoninternet.net">canalswans</a>
-			</li>
-			<li data-lang="en" id="kira">
+			</span></li>
+			<li data-lang="en" id="kira"><span>
 				<a href="http://kira.eight45.net">Kira's Web-Treehouse</a>
-			</li>
-			<li data-lang="en" id="chotrin">
+			</span></li>
+			<li data-lang="en" id="chotrin"><span>
 				<a href="https://chotrin.org">chötrin's wiki.</a>
 				<a href="https://chotrin.org/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="emile">
+			</span></li>
+			<li data-lang="en" id="emile"><span>
 				<a href="https://emile.space">emile.space.</a>
 				<a href="https://emile.space/twtxt.txt" class="twtxt">twtxt</a>
-			</li>
-			<li data-lang="en" id="198">
+			</span></li>
+			<li data-lang="en" id="198"><span>
 				<a href="https://mayaks.eu">mayaks</a>
-			</li>
-			<li data-lang="en" id="vitbaisa">
+			</span></li>
+			<li data-lang="en" id="vitbaisa"><span>
 				<a href="https://vit.baisa.cz">vitbaisa</a>
 				<a href="https://vit.baisa.cz/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="fr" id="bloguslibrus">
+			</span></li>
+			<li data-lang="fr" id="bloguslibrus"><span>
 				<a href="https://www.bloguslibrus.fr">bloguslibrus</a>
 				<a href="https://www.bloguslibrus.fr/atom.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="kxvin">
+			</span></li>
+			<li data-lang="en" id="kxvin"><span>
 				<a href="https://www.kxvin.com">kxvin</a>
-			</li>
-			<li data-lang="en" id="nebula">
+			</span></li>
+			<li data-lang="en" id="nebula"><span>
 				<a href="https://nebula.ed1.club/stuff/">nebula.ed1.club</a>
-			</li>
-			<li data-lang="en" id="plungepool">
+			</span></li>
+			<li data-lang="en" id="plungepool"><span>
 				<a href="https://wiki.plungepool.dev">plungepool</a>
-			</li>
-			<li data-lang="en" id="strickinato">
+			</span></li>
+			<li data-lang="en" id="strickinato"><span>
 				<a href="https://aaronstrick.com">strickinato</a>
 				<a href="https://aaronstrick.com/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="ghettobastler">
+			</span></li>
+			<li data-lang="en" id="ghettobastler"><span>
 				<a href="https://ghettobastler.com">ghettobastler</a>
-			</li>
-			<li data-lang="en zh" id="ayu">
+			</span></li>
+			<li data-lang="en zh" id="ayu"><span>
 				<a href="https://ayu.land">Sweetfish Ayu</a>
 				<a href="https://ayu.land/rss.en.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="tosatur">
+			</span></li>
+			<li data-lang="en" id="tosatur"><span>
 				<a href="https://tosatur.com">tosatur</a>
 				<a href="https://tosatur.com/notes/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="pfych">
+			</span></li>
+			<li data-lang="en" id="pfych"><span>
 				<a href="https://pfy.ch">pfych</a>
 				<a href="https://pfy.ch/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="benji">
+			</span></li>
+			<li data-lang="en" id="benji"><span>
 				<a href="https://benji.dog">benji</a>
 				<a href="https://benji.dog/twtxt.txt" class="twtxt">twtxt</a>
 				<a href="https://benji.dog/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://benji.dog/assets/88x31.png" width="88" height="31">
-			</li>
-			<li data-lang="en" id="manifoldslug">
+			</span></li>
+			<li data-lang="en" id="manifoldslug"><span>
 				<a href="http://wreckage.link">manifoldslug</a>
 				<a href="http://wreckage.link/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="h3rald">
+			</span></li>
+			<li data-lang="en" id="h3rald"><span>
 				<a href="https://h3rald.com">h3rald</a>
-			</li>
-			<li data-lang="en" id="louisload">
+			</span></li>
+			<li data-lang="en" id="louisload"><span>
 				<a href="https://luis.zip">louisload</a>
 				<a href="https://luis.zip/blog/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="foreverlikethis">
+			</span></li>
+			<li data-lang="en" id="foreverlikethis"><span>
 				<a href="https://foreverliketh.is/">foreverliketh.is</a>
 				<a href="https://foreverliketh.is/blog/index.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://foreverliketh.is/docs/connectivism/home-page/buttons/foreverliketh.is.png" width="88" height="31">
-			</li>
-			<li data-lang="en" id="monoxane">
+			</span></li>
+			<li data-lang="en" id="monoxane"><span>
 				<a href="https://monoxane.io">monoxane</a>
-			</li>
-			<li data-lang="en" id="lndf">
+			</span></li>
+			<li data-lang="en" id="lndf"><span>
 				<a href="https://lndf.fr">lndf</a>
-			</li>
-			<li data-lang="en" id="ratfactor">
+			</span></li>
+			<li data-lang="en" id="ratfactor"><span>
 				<a href="http://ratfactor.com">ratfactor</a>
 				<a href="http://ratfactor.com/atom.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="invisible-ink">
+			</span></li>
+			<li data-lang="en" id="invisible-ink"><span>
 				<a href="https://hideout.ink">squid</a>
 				<a href="https://hideout.ink" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="wilbur">
+			</span></li>
+			<li data-lang="en" id="wilbur"><span>
 				<a href="https://wilburzhang.com">Wilbur Zhang</a>
-			</li>
-			<li data-lang="en" id="parthshiralkar">
+			</span></li>
+			<li data-lang="en" id="parthshiralkar"><span>
 				<a href="https://parth.ninja/">Parth Shiralkar</a>
 				<a href="https://parth.ninja/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="malloc">
+			</span></li>
+			<li data-lang="en" id="malloc"><span>
 				<a href="http://malloc.dog">malloc</a>
 				<a href="http://malloc.dog/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="shrik3">
+			</span></li>
+			<li data-lang="en" id="shrik3"><span>
 				<a href="https://shrik3.com">shrik3</a>
 				<a href="https://shrik3.com/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="ginseng">
+			</span></li>
+			<li data-lang="en" id="ginseng"><span>
 				<a href="https://gi.nseng.art">Shuang Jiang</a>
-			</li>
-			<li data-lang="en" id="zinzy">
+			</span></li>
+			<li data-lang="en" id="zinzy"><span>
 				<a href="https://zinzy.website">Zinzy Waleson Geene</a>
 				<a href="https://www.zinzy.website/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="mattmcadams">
+			</span></li>
+			<li data-lang="en" id="mattmcadams"><span>
 				<a href="https://mattmcadams.com">Matt McAdams</a>
 				<a href="https://www.mattmcadams.com/feed/feed.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="lukaprincic">
+			</span></li>
+			<li data-lang="en" id="lukaprincic"><span>
 				<a href="https://prin.lu">Luka Prinčič / Prince Lucija</a>
 				<img loading="lazy" src='https://prin.lu/lib/icons/prin.lu.88x31.png' width="88" height="31">
-			</li>
-			</li>
-			<li data-lang="en" id="grains">
+			</span></li>
+			</span></li>
+			<li data-lang="en" id="grains"><span>
 				<a href="https://grains.cc">grains.cc</a>
-			</li>
-			<li data-lang="en" id="proto">
+			</span></li>
+			<li data-lang="en" id="proto"><span>
 				<a href="https://proto.garden">proto.garden</a>
 				<a href="https://proto.garden/rss/notes.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="sid">
+			</span></li>
+			<li data-lang="en" id="sid"><span>
 				<a href="https://kjelsrud.dev">kjelsrud.dev</a>
 				<a href="https://kjelsrud.dev/rss.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="jared">
+			</span></li>
+			<li data-lang="en" id="jared"><span>
 				<a href="https://jaredforth.com">jaredforth.com</a>
-			</li>
-			<li data-lang="en" id="aksui">
+			</span></li>
+			<li data-lang="en" id="aksui"><span>
 				<a href="https://aksui.com/">Aksui</a>
-			</li>
-			<li data-lang="en" id="fem">
+			</span></li>
+			<li data-lang="en" id="fem"><span>
 				<a href="http://femishonuga.com">femishonuga.com</a>
-			</li>
-			<li data-lang="en" id="strengthofone">
+			</span></li>
+			<li data-lang="en" id="strengthofone"><span>
 				<a href="http://strengthofone.com">strengthofone.com</a>
-			</li>
-			<li data-lang="en" id="crash">
+			</span></li>
+			<li data-lang="en" id="crash"><span>
 				<a href="http://crash.money">crash.money</a>
-			</li>
-			<li data-lang="en" id="sunil">
+			</span></li>
+			<li data-lang="en" id="sunil"><span>
 				<a href="https://garden.sunils.in">sunil's garden</a>
-			</li>
-			<li data-lang="en" id="zoeblade">
+			</span></li>
+			<li data-lang="en" id="zoeblade"><span>
 				<a href="https://notebook.zoeblade.com">Zoë Blade's Notebook</a>
-			</li>
-			<li data-lang="en" id="beespace">
+			</span></li>
+			<li data-lang="en" id="beespace"><span>
 				<a href="https://lunabee.space/extraspace/port.html">beespace</a>
 				<a href="https://lunabee.space/beespace.atom" class="rss">rss</a>
 				<img loading="lazy" src="https://lunabee.space/8831.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="jakintosh">
+			</span></li>
+			<li data-lang="en" id="jakintosh"><span>
 				<a href="http://jakintosh.com">jakintosh.com</a>
-			</li>
-			<li data-lang="en" id="dziban">
+			</span></li>
+			<li data-lang="en" id="dziban"><span>
 				<a href="https://dziban.net">Dziban</a>
-			</li>
-			<li data-lang="en" id="Hellien">
+			</span></li>
+			<li data-lang="en" id="Hellien"><span>
 				<a href="https://www.huotart.com">Hellien</a>
-			</li>
-			<li lang="en" id="slewis">
+			</span></li>
+			<li lang="en" id="slewis"><span>
 				<a href="https://slewis.wiki/">slewis.wiki</a>
 				<img loading="lazy" src='https://slewis.wiki/media/main_button.png' width="88" height="31">
-			</li>
-			<li data-lang="en" id="drawkcab">
+			</span></li>
+			<li data-lang="en" id="drawkcab"><span>
 				<a href="https://www.drawk.cab/">drawk.cab</a>
-			</li>
-			<li lang="en" id="knights">
+			</span></li>
+			<li lang="en" id="knights"><span>
 				<a href="https://guerrero.ph">guerrero.ph</a>
-			</li>
-			<li data-lang="en" id="plantay">
+			</span></li>
+			<li data-lang="en" id="plantay"><span>
 				<a href="https://plantay.me">Plantay</a>
-			</li>
-			<li data-lang="en" id="alexeystar">
+			</span></li>
+			<li data-lang="en" id="alexeystar"><span>
 				<a href="https://alexeystar.com/">alexeystar.com</a>
 				<a href="https://www.alexeystar.com/index.xml" class="rss">rss</a>
-			</li>
-			<li data-lang="en" id="22h49">
+			</span></li>
+			<li data-lang="en" id="22h49"><span>
 				<a href="https://22h49.one">22h49</a>
 				<a href="https://22h49.one/zine/atom.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://22h49.one/images/button.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="laeastra">
+			</span></li>
+			<li data-lang="en" id="laeastra"><span>
 				<a href="https://laeastra.com">laeastra</a>
-			</li>
-			<li data-lang="en" id="RNA">
+			</span></li>
+			<li data-lang="en" id="RNA"><span>
 				<a href="https://ribo.zone/neighborhood">ribo.zone</a>
 				<a href="https://ribo.zone/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://ribo.zone/88x31/site/ribozone.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="visualculture">
+			</span></li>
+			<li data-lang="en" id="visualculture"><span>
 				<a href="https://visualculture.vc">visualculture</a>
 				<img loading="lazy" src="https://visualculture.vc/assets/images/button.png" width="88" height="31">
-			</li>
-			<li data-lang="en" id="leet">
+			</span></li>
+			<li data-lang="en" id="leet"><span>
 				<a href="https://leetusman.com">leetusman.com</a>
 				<a href="https://leetusman.com/nosebook/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://leetusman.com/assets/img/badge.gif" width="88" height="31">
-			</li>
-			<li data-lang="en" id="arnexyz">
+			</span></li>
+			<li data-lang="en" id="arnexyz"><span>
 				<a href="https://arne.xyz">arne.xyz</a>
 				<a href="https://arne.xyz/feed/" class="rss">rss</a>
 				<img loading="lazy" src="https://arne.xyz/arnexyz.gif" width="88" height="31" >
-			</li>
-			<li data-lang="en" id="triapul">
+			</span></li>
+			<li data-lang="en" id="triapul"><span>
 				<a href="https://triapul.cz/">triapul.cz</a>
-			</li>
-			<li data-lang="en" id="churchbasement">
+			</span></li>
+			<li data-lang="en" id="churchbasement"><span>
 				<a href="https://churchbasement.org/">church basement</a>
-			</li>
+			</span></li>
 		</ol>
 		<footer>
 			<p class="readme">
@@ -832,7 +832,7 @@
 			body > footer > img { display: inline-block; width: 100px; height: auto; margin-bottom: -5px; margin-bottom: 30px; }
 			body:target > ol li a.twtxt, html:target li a.rss { background: var(--color-beta); color: var(--color-alpha); display: inline; }
 			body:target > footer > p > span.hide, html:target footer > p > span.hide { display: inline; }
-			body > ol:target > li > img { display:block; }
+			body > ol:target > li img { display:block; }
 			body > ol > li:target a { color: var(--color-alpha); }
 			body > ol > li:target { background: var(--color-beta); }
 			@media screen and (max-width: 800px) { body > ol { column-count: 2; } }


### PR DESCRIPTION
li (list item) tags necessarily have a CSS display of "list-item", which may cause their contents to spill across the ends of columns. By wrapping their contents with a span tag, the contents are fit into an "inline" element and stick together.