### PR TITLE
add falai.se

### DIFF
--- a/index.html
+++ b/index.html
@@ -819,6 +819,10 @@
 				<a href="https://adamledoux.net/blog/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src='https://adamledoux.net/images/button.png' width="88" height="31">
 			</li>
+			<li data-lang="en" id="artsun">
+				<a href="https://falai.se">falai.se</a>
+				<img loading="lazy" src='https://falai.se/images/global/falaise_banner.png' width="88" height="31">
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
Adding https://falai.se to the ring.
Compliant banner is here: https://falai.se/images/global/banner.png  
No RSS yet.