### PR TITLE
Add jack.leightcap.com to the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -843,6 +843,9 @@
 				<a href="https://monolyt.co/feed.xml" class="rss">rss</a>
 				<img loading="lazy" src='https://monolyt.co/assets/banner-monolyt.gif' width="88" height="31">
       </li>
+      <li data-lang="en" id="jleightcap">
+				<a href="https://jack.leightcap.com">Jack Leightcap</a>
+      </li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
Hello o/

I had made a pass at a website in https://github.com/XXIIVV/webring/pull/910, but was having a hard time thinking outside the small box of tech blogs standard in my mind.
The wiki-structure of xxiivv.com 100r.co kokorobot.ca really made an impression on me, especially the use of a distinct visual language---all the more impressive to me as I took passes at my own realization, and hugely struggled with the structuring: how to fit my work, and myself--what parts of myself?--into the really explicit kind of hierarchies that make up the sites.

The is webring linked at my 'root' here: <https://jack.leightcap.com/>, and the seed of my research wiki here: <https://oscillistor.net>.

I appreciated your feedback before and hope you'll take another look! I'll have to DM on Mastodon to introduce myself proper sometime
