### PR TITLE
Moved subdomain for simone.computer

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,8 +279,8 @@
 			</li>
 			<li data-lang="en ita" id="109">
 				<a href="https://simone.computer">Simone's Computer</a>
-				<a href="https://system31.simone.computer/rss.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://system31.simone.computer/assets/88x31.gif" width="88" height="31">
+				<a href="https://blog.simone.computer/rss.xml" class="rss">rss</a>
+				<img loading="lazy" src="https://blog.simone.computer/assets/88x31.gif" width="88" height="31">
 			</li>
 			<li data-lang="en es eo" id="0x6c88354e70">
 				<a href="https://sunshinegardens.org/~xj9/">dreamspace</a>


### PR DESCRIPTION
I've updated the URLs for 88x31 and RSS feed from `system31.simone.computer` to `blog.simone.computer`