### PR TITLE
Idiomdrottning

### DIFF
--- a/index.html
+++ b/index.html
@@ -912,6 +912,12 @@
 				<a href="https://stage7.net/rss/rss.xml" class="rss">rss</a>
 				<img loading="lazy" src="https://stage7.net/links/stage7.png" alt="stage7" width="88" height="31">
 			</li>
+			<li data-lang="en" id="Idiomdrottning">
+				<a href="https://idiomdrottning.org">Idiomdrottning</a>
+				<a href="https://idiomdrottning.org/blog.txt" class="twtxt">twtxt</a>
+				<a href="https://idiomdrottning.org/blog" class="rss">rss</a>
+				<img loading="lazy" src="https://idiomdrottning.org/button.svg" alt="Idiomdrottning" width="88" height="31">
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
The webring link is in three places, at the bottom right of the
/gallery and /texts and on the front page / . I removed the target
blank and made it just normal links. On the /texts page I moved the
word "webring" from the alt text to the a element because it's a
/texts page.

Also my PR didn' have this stuff first because github confusion. it was in the commit message. I'm more used to using git without hub