### PR TITLE
Add dill64

### DIFF
--- a/index.html
+++ b/index.html
@@ -938,6 +938,11 @@
 				<a href="https://nnix.com">nnix</a>
 				<img loading="lazy" src="https://nnix.com/banner.webp" alt="nnix" width="88" height="31">
       </li>
+			<li data-lang="en" id="dill64">
+				<a href="https://dill64.com">Dill64</a>
+				<img loading="lazy" src="https://www.dill64.com/images/dill64Banner.png" alt="dill64 banner" width="88" height="31" style="image-rendering: pixelated;">
+				<a href="https://www.dill64.com/rss.xml" class="rss">rss</a>
+      		</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
Hi,

I would like to add my site [https://www.dill64.com](https://www.dill64.com) to the webring.

I have the webring logo on the footer of my home page, and at the top of most other pages.

You can find my about page [https://www.dill64.com/about.html](https://www.dill64.com/about.html) clicking the robot icon on the home page

Thanks!