### PR TITLE
Update domain for wolf.md to wol.fm

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,9 +389,9 @@
 				<a href="https://notebook.wesleyac.com/atom.xml" class="rss">rss</a>
 			</li>
 			<li data-lang="en" id="141">
-				<a href="https://wolfmd.me">wolfmd</a>
-				<a href="https://wolfmd.me/feed.xml" class="rss">rss</a>
-				<img loading="lazy" src="https://wolfmd.me/img/banner.gif" width="88" height="31">
+				<a href="https://wol.fm">wolfm</a>
+				<a href="https://wol.fm/feed.xml" class="rss">rss</a>
+				<img loading="lazy" src="https://wol.fm/img/banner.gif" width="88" height="31">
 			</li>
 			<li data-lang="en" id="143">
 				<a href="https://void.cc">automata / vilson vieira</a>

--- a/webring.opml
+++ b/webring.opml
@@ -46,7 +46,7 @@
     <outline type="rss" text="metasyn" title="metasyn" description="" version="RSS" htmlUrl="https://metasyn.pw" xmlUrl="https://metasyn.pw/rss.xml"/>
     <outline type="rss" text="neeasade" title="neeasade" description="" version="RSS" htmlUrl="https://notes.neeasade.net/" xmlUrl="https://notes.neeasade.net/rss.xml"/>
     <outline type="rss" text="wesleyac" title="wesleyac" description="" version="RSS" htmlUrl="https://notebook.wesleyac.com" xmlUrl="https://notebook.wesleyac.com/atom.xml"/>
-    <outline type="rss" text="wolfmd" title="wolfmd" description="" version="RSS" htmlUrl="https://wolfmd.me" xmlUrl="https://wolfmd.me/feed.xml"/>
+    <outline type="rss" text="wolfm" title="wolfm" description="" version="RSS" htmlUrl="https://wol.fm" xmlUrl="https://wol.fm/feed.xml"/>
     <outline type="rss" text="corvid cafe" title="corvid cafe" description="" version="RSS" htmlUrl="https://corvid.cafe/" xmlUrl="https://corvid.cafe/feed.xml"/>
     <outline type="rss" text="alessia bellisario" title="alessia bellisario" description="" version="RSS" htmlUrl="https://aless.co" xmlUrl="https://aless.co/rss.xml"/>
     <outline type="rss" text="mrshll" title="mrshll" description="" version="RSS" htmlUrl="https://mrshll.com" xmlUrl="https://mrshll.com/feed.rss"/>


### PR DESCRIPTION
In an act of impulsive vanity, I purchased a domain name that is three letters shorter and less suggestive of me having medical credentials. Updates the link and rss feed for wolfmd.me to wol.fm.

I intend on maintaining both domains for the foreseeable future but I feel obligated to make use of the cooler (it is cooler, right?) domain whenever possible

An update to the button will be made in conjunction to this PR

Holler at me if I need to make any adjustments to this commit or otherwise and thank you for helping build this awesome community