### PR TITLE
Add caleidoscode to the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -977,6 +977,10 @@
 				<a href="https://xo.codes">xo</a>
 				<img loading="lazy" src="https://xo.codes/img/banner.gif" alt="xo" width="88" height="31">
 			</li>
+			<li data-lang="en" id="caleidoscode">
+				<a href="https://caleidoscode.io">caleidoscode</a>
+				<img loading="lazy" src="https://caleidoscode.io/button.png" alt="caleidoscode" width="88" height="31">
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
hi! i'd like to add caleidoscode (https://caleidoscode.io) to the webring. i added the webring icon to the footer of every page, next to "part of the XXIIVV webring". it is on my own domain, not a github page, it has the required amount of content pages including an about page, and of course it is readable and navigable with javascript disabled (the interactive bits are just extras on top). i also added my 88x31 button, hosted at https://caleidoscode.io/button.png. first time joining a ring, thank you for this!