### PR TITLE
Add aaronmassicotte.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -977,6 +977,11 @@
 				<a href="https://xo.codes">xo</a>
 				<img loading="lazy" src="https://xo.codes/img/banner.gif" alt="xo" width="88" height="31">
 			</li>
+			<li data-lang="en" id="aaronmassicotte">
+				<a href="https://aaronmassicotte.com">Aaron Massicotte</a>
+				<a href="https://aaronmassicotte.com/index.xml" class="rss">rss</a>
+				<img loading="lazy" src="https://aaronmassicotte.com/webring-button.png" alt="Aaron Massicotte" width="88" height="31">
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
Adding my personal site to the webring.

The webring icon is live in the site footer, visible on every page (e.g. https://aaronmassicotte.com/ ), linking to https://webring.xxiivv.com/#aaronmassicotte

- 88x31 banner: https://aaronmassicotte.com/webring-button.png
- RSS: https://aaronmassicotte.com/index.xml

The site is a static, hand-crafted personal site (writing, recipes, photography) with an about page and well over 10 content pages; content is navigable without JavaScript.