### PR TITLE
Add stik.wtf

### DIFF
--- a/index.html
+++ b/index.html
@@ -997,6 +997,11 @@
 				<a href="https://merc.guru">merc</a>
 				<img loading="lazy" src="https://merc.guru/assets/mercbutton.png" alt="merc.guru" width="88" height="31">
 </li>
+			<li data-lang="en" id="stik">
+				<a href="https://stik.wtf">stik</a>
+				<a href="https://stik.wtf/index.xml" class="rss">rss</a>
+				<img loading="lazy" src="https://stik.wtf/badges/stik-wtf.svg" alt="stik.wtf" width="88" height="31">
+			</li>
 		</ol>
 		<footer>
 			<p class="readme">


### PR DESCRIPTION
Adding stik.wtf to the ring.

**Webring icon location:** https://stik.wtf/wall/ — self-hosted per the README, links to https://webring.xxiivv.com/#stik, inverts for dark mode.

The site: hand-written Hugo templates + hand-written CSS, self-hosted in an LXC container on my own Proxmox node behind a Cloudflare tunnel. Homelab and project pages with dated update logs, a now page, a guestbook and 88x31 wall — all content is markdown, every page works without JavaScript, ~17KB a page. 88x31 lives at https://stik.wtf/badges/stik-wtf.svg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)